### PR TITLE
Return it when error occurs

### DIFF
--- a/pkg/dock/api/api.go
+++ b/pkg/dock/api/api.go
@@ -200,7 +200,7 @@ func DeleteVolumeAttachment(req *pb.DockRequest) (*pb.DockResponse, error) {
 				return &pb.DockResponse{}, err
 			}
 		}
-		return &pb.DockResponse{}, nil
+		return &pb.DockResponse{}, err
 	}
 
 	if err := db.C.DeleteVolumeAttachment(req.GetVolumeId(), req.GetAttachmentId()); err != nil {


### PR DESCRIPTION
In dock api module, if some errors occur during deleting volume
attachment, the error should be returned rather than being ignored.
So it was a bug and should be fixed immediately.