### PR TITLE
Refactor dock server structure in grpc module

### DIFF
--- a/cmd/osdsdock/osdsdock.go
+++ b/cmd/osdsdock/osdsdock.go
@@ -85,5 +85,5 @@ func main() {
 	// Construct dock module grpc server struct and do some initialization.
 	ds := dockServer.NewDockServer(apiEdp)
 	// Start the listen mechanism of dock module.
-	ds.ListenAndServe()
+	dockServer.ListenAndServe(ds)
 }

--- a/pkg/grpc/dock/server/server_test.go
+++ b/pkg/grpc/dock/server/server_test.go
@@ -1,0 +1,15 @@
+// Copyright (c) 2016 Huawei Technologies Co., Ltd. All Rights Reserved.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License"); you may
+//    not use this file except in compliance with the License. You may obtain
+//    a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+//    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+//    License for the specific language governing permissions and limitations
+//    under the License.
+
+package server


### PR DESCRIPTION
In the go formal way, all structure constructing function should
return with interface, one of reason is that they need to comply
with the inheritance conduction of unified interface. Besides,
the seperation between structure and interface will make it easier
for unit test.