### PR TITLE
Add makefile to replace building function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+.PHONY: all build package osdsdock osdslet docker clean
+
+all:build
+
+build:osdsdock osdslet
+
+package:
+	go get github.com/opensds/opensds/cmd/osdslet
+	go get github.com/opensds/opensds/cmd/osdsdock
+
+osdsdock:package
+	mkdir -p  ./build/out/bin/
+	go build -o ./build/out/bin/osdsdock github.com/opensds/opensds/cmd/osdsdock
+
+osdslet:package
+	mkdir -p  ./build/out/bin/
+	go build -o ./build/out/bin/osdslet github.com/opensds/opensds/cmd/osdslet
+
+docker:build
+	cp ./build/out/bin/osdsdock ./cmd/osdsdock
+	cp ./build/out/bin/osdslet ./cmd/osdslet
+	docker build cmd/osdsdock -t opensds/opensds-dock:v1alpha
+	docker build cmd/osdslet -t opensds/opensds-controller:v1alpha
+
+clean:
+	rm -rf ./build/out/bin/* ./cmd/osdslet ./cmd/osdsdock

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-go get github.com/opensds/opensds/cmd/osdslet
-go get github.com/opensds/opensds/cmd/osdsdock
-
-go install github.com/opensds/opensds/cmd/osdslet
-go install github.com/opensds/opensds/cmd/osdsdock

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-go get github.com/opensds/opensds/cmd/osdslet
-go get github.com/opensds/opensds/cmd/osdsdock
-
-(cd cmd/osdslet && ./build_docker.sh)
-(cd cmd/osdsdock && ./build_docker.sh)

--- a/cmd/osdsdock/build_docker.sh
+++ b/cmd/osdsdock/build_docker.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-go build
-
-docker build . -t opensds/opensds-dock:v1alpha

--- a/cmd/osdslet/build_docker.sh
+++ b/cmd/osdslet/build_docker.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-go build
-
-docker build . -t opensds/opensds-controller:v1alpha


### PR DESCRIPTION
Add makefile to instead the building shell script.
Usage:
Execute command int opensds root directory.
Exeucte `make` to build osdsdock and osdsdlet
Exeucte `make osdsdock` to build osdsdock
Exeucte `make osdslet` to build osdslet
Exeucte `make docker` to build docker images.
Exeucte `make clean` to bin files.
