### PR TITLE
Add sample driver for test

### DIFF
--- a/pkg/dock/discovery/discovery.go
+++ b/pkg/dock/discovery/discovery.go
@@ -56,6 +56,7 @@ func (dd *DockDiscoverer) Init() error {
 	name2Backend := map[string]BackendProperties{
 		"ceph":   BackendProperties(CONF.Ceph),
 		"cinder": BackendProperties(CONF.Cinder),
+		"sample": BackendProperties(CONF.Sample),
 	}
 
 	host, err := os.Hostname()

--- a/pkg/utils/config/config_define.go
+++ b/pkg/utils/config/config_define.go
@@ -46,8 +46,8 @@ type BackendProperties struct {
 }
 
 type Ceph BackendProperties
-
 type Cinder BackendProperties
+type Sample BackendProperties
 
 type Config struct {
 	Default  `conf:"default"`
@@ -56,6 +56,7 @@ type Config struct {
 	Database `conf:"database"`
 	Ceph     `conf:"ceph"`
 	Cinder   `conf:"cinder"`
+	Sample   `conf:"sample"`
 	Flag     FlagSet
 }
 
@@ -74,3 +75,4 @@ func (c *Config) Load(confFile string) {
 }
 
 var CONF *Config = GetDefaultConfig()
+

--- a/pkg/utils/config/config_test.go
+++ b/pkg/utils/config/config_test.go
@@ -262,6 +262,9 @@ func TestOpensdsConfig(t *testing.T) {
 	if CONF.OsdsDock.EnableBackends[1] != "cinder" {
 		t.Error("Test OsdsDock.EnableBackends[1] error")
 	}
+	if CONF.OsdsDock.EnableBackends[2] != "sample" {
+		t.Error("Test OsdsDock.EnableBackends[2] error")
+	}
 	if CONF.Database.Credential != "opensds:password@127.0.0.1:3306/dbname" {
 		t.Error("Test Database.Credential error")
 	}
@@ -289,5 +292,15 @@ func TestOpensdsConfig(t *testing.T) {
 	if CONF.Cinder.DriverName != "cinder" {
 		t.Error("Test Cinder.DriverName error")
 	}
+	if CONF.Sample.Name != "sample" {
+		t.Error("Test Sample.Name error")
+	}
+	if CONF.Sample.Description != "Sample Test" {
+		t.Error("Test Sample.Description error")
+	}
+	if CONF.Sample.DriverName != "sample" {
+		t.Error("Test Sample.DriverName error")
+	}
 
 }
+

--- a/pkg/utils/config/testdata/opensds.conf
+++ b/pkg/utils/config/testdata/opensds.conf
@@ -7,7 +7,7 @@ socket_order = inc
 [osdsdock]
 api_endpoint = localhost:50050
 log_file = /var/log/opensds/osdsdock.log
-enabled_backends = ceph,cinder
+enabled_backends = ceph,cinder,sample
 
 [ceph]
 name = ceph
@@ -18,6 +18,11 @@ driver_name = ceph
 name = cinder
 description = Cinder Test
 driver_name = cinder
+
+[sample]
+name = sample
+description = Sample Test
+driver_name = sample
 
 [database]
 credential = opensds:password@127.0.0.1:3306/dbname
@@ -55,3 +60,4 @@ slice_uint32=1,2,3
 slice_uint64=1,2,3
 slice_float32=1,-0.2,0.3
 slice_float64=1,-0.2,0.3
+


### PR DESCRIPTION
Modifed config and discovery to support the sample driver, so that developer can just modify the config file to used sample driver for testing.