### PR TITLE
Add pool config feature

### DIFF
--- a/contrib/drivers/openstack/cinder/testdata/cinder.yaml
+++ b/contrib/drivers/openstack/cinder/testdata/cinder.yaml
@@ -6,3 +6,12 @@ authOptions:
   password: "admin"
   tenantId: "04154b841eb644a3947506c54fa73c76"
   tenantName: "admin"
+pool:
+  pool1:
+    diskType: SSD
+    iops: 1000
+    bandwidth: 1000
+  pool2:
+    diskType: SAS
+    iops: 800
+    bandwidth: 800


### PR DESCRIPTION
Add pool config feature. Adminitrator can add some properties(DiskType, IOPS, BandWidth etc.) to the pools so that OpenSDS scheduler can alloc volume according these properties automatic.And it will also takes on the white list function, that the the user only can see the pool which is added into the config file.The configuration would be like this:
``` yaml
pool:
  pool1:
    diskType: SSD
    iops: 1000
    bandwidth: 1000
  pool2:
    diskType: SAS
    iops: 800
    bandwidth: 800
```