### PR TITLE
Optimize the global configuration usage for driver developer.

### DIFF
--- a/pkg/utils/config/config_define.go
+++ b/pkg/utils/config/config_define.go
@@ -14,10 +14,6 @@
 
 package config
 
-import (
-	gflag "flag"
-)
-
 type Default struct{}
 
 type OsdsLet struct {
@@ -46,35 +42,19 @@ type BackendProperties struct {
 	DriverName  string `conf:"driver_name"`
 }
 
-type Ceph BackendProperties
-type Cinder BackendProperties
-type Sample BackendProperties
-type LVM BackendProperties
+type Backends struct {
+	Ceph   BackendProperties `conf:"ceph"`
+	Cinder BackendProperties `conf:"cinder"`
+	Sample BackendProperties `conf:"sample"`
+	LVM    BackendProperties `conf:"lvm"`
+}
 
 type Config struct {
 	Default  `conf:"default"`
 	OsdsLet  `conf:"osdslet"`
 	OsdsDock `conf:"osdsdock"`
 	Database `conf:"database"`
-	Ceph     `conf:"ceph"`
-	Cinder   `conf:"cinder"`
-	Sample   `conf:"sample"`
-	LVM      `conf:"lvm"`
-	Flag     FlagSet
+	Backends
+	Flag FlagSet
 }
 
-//Create a Config and init default value.
-func GetDefaultConfig() *Config {
-	var conf *Config = new(Config)
-	initConf("", conf)
-	return conf
-}
-
-func (c *Config) Load(confFile string) {
-	gflag.StringVar(&confFile, "config-file", confFile, "The configuration file of OpenSDS")
-	c.Flag.Parse()
-	initConf(confFile, CONF)
-	c.Flag.AssignValue()
-}
-
-var CONF *Config = GetDefaultConfig()

--- a/pkg/utils/config/config_test.go
+++ b/pkg/utils/config/config_test.go
@@ -17,6 +17,8 @@ package config
 import (
 	"reflect"
 	"testing"
+
+	"github.com/go-ini/ini"
 )
 
 type TestStruct struct {
@@ -61,7 +63,8 @@ type TestConfig struct {
 
 func TestFunctionAllType(t *testing.T) {
 	conf := &TestConfig{}
-	initConf("testdata/opensds.conf", conf)
+	cfg, _ := ini.Load("testdata/opensds.conf")
+	doInit(cfg, conf)
 	if conf.TestStruct.Bool != true {
 		t.Error("Test TestStuct Bool error")
 	}
@@ -154,7 +157,8 @@ func TestFunctionAllType(t *testing.T) {
 
 func TestFunctionDefaultValue(t *testing.T) {
 	conf := &TestConfig{}
-	initConf("NotExistFile", conf)
+	cfg, _ := ini.Load("NotExistFile")
+	doInit(cfg, conf)
 	if conf.TestStruct.Bool != true {
 		t.Error("Test TestStuct Bool error")
 	}
@@ -274,6 +278,9 @@ func TestOpensdsConfig(t *testing.T) {
 	if CONF.Database.Driver != "etcd" {
 		t.Error("Test Database.Driver error")
 	}
+	if CONF.Backends.Ceph.Name != "ceph" {
+		t.Error("Test Ceph.Backends.Name error")
+	}
 	if CONF.Ceph.Name != "ceph" {
 		t.Error("Test Ceph.Name error")
 	}
@@ -301,6 +308,18 @@ func TestOpensdsConfig(t *testing.T) {
 	if CONF.Sample.DriverName != "sample" {
 		t.Error("Test Sample.DriverName error")
 	}
-
+	bm := GetBackendsMap()
+	if bm["ceph"].Name != "ceph" {
+		t.Error("Test bm[\"ceph\"].Name error")
+	}
+	if bm["cinder"].Name != "cinder" {
+		t.Error("Test bm[\"cinder\"].Name error")
+	}
+	if bm["sample"].Name != "sample" {
+		t.Error("Test bm[\"sample\"].Name error")
+	}
+	if _, ok := bm["lvm"]; !ok {
+		t.Error("Test bm[\"lvm\"].Name error")
+	}
 }
 


### PR DESCRIPTION
Packaged the storage backends in the structure `Backends`. So one storage backend driver  can be added by modifying only one part of configuation structure code.