### PR TITLE
Add the filters about the AZ, Capacity, DiskType, etc.

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -21,12 +21,14 @@ package controller
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	log "github.com/golang/glog"
 
 	"github.com/opensds/opensds/pkg/controller/policy"
 	"github.com/opensds/opensds/pkg/controller/selector"
 	"github.com/opensds/opensds/pkg/controller/volume"
+	"github.com/opensds/opensds/pkg/db"
 	pb "github.com/opensds/opensds/pkg/dock/proto"
 	"github.com/opensds/opensds/pkg/model"
 )
@@ -42,37 +44,58 @@ var Brain *Controller
 
 func NewController() *Controller {
 	return &Controller{
-		Selector:         selector.NewSelector(),
+		selector:         selector.NewSelector(),
 		volumeController: volume.NewController(),
 	}
 }
 
 type Controller struct {
-	selector.Selector
-
+	selector         selector.Selector
 	volumeController volume.Controller
 	policyController policy.Controller
 }
 
 func (c *Controller) CreateVolume(in *model.VolumeSpec) (*model.VolumeSpec, error) {
-	var prfID = in.GetProfileId()
 
-	prf, err := c.SelectProfile(prfID)
+	var profile *model.ProfileSpec
+	var err error
+
+	if in.ProfileId == "" {
+		log.Warning("Use default profile when user doesn't specify profile.")
+		profile, err = db.C.GetDefaultProfile()
+	} else {
+		profile, err = db.C.GetProfile(in.ProfileId)
+	}
 	if err != nil {
-		log.Error("when search profiles in db:", err)
+		log.Error("Get profile failed: ", err)
 		return nil, err
 	}
 
+	if in.Size <= 0 {
+		errMsg := fmt.Sprintf("Invalid volume size: %d", in.Size)
+		log.Error(errMsg)
+		return nil, errors.New(errMsg)
+	}
+
+	if in.AvailabilityZone == "" {
+		log.Warning("Use default availability zone when user doesn't specify availabilityZone.")
+		in.AvailabilityZone = "default"
+	}
+
 	// Select the storage tag according to the lifecycle flag.
-	c.policyController = policy.NewController(prf)
+	c.policyController = policy.NewController(profile)
 	c.policyController.Setup(CREATE_LIFECIRCLE_FLAG)
 
-	polInfo, err := c.SelectSupportedPool(c.policyController.StorageTag().GetSyncTag())
+	filterRequest := profile.Extra
+	filterRequest["size"] = in.Size
+	filterRequest["availabilityZone"] = in.AvailabilityZone
+
+	polInfo, err := c.selector.SelectSupportedPool(filterRequest)
 	if err != nil {
 		log.Error("When search supported pool resource:", err)
 		return nil, err
 	}
-	dockInfo, err := c.SelectDock(polInfo)
+	dockInfo, err := db.C.GetDock(polInfo.DockId)
 	if err != nil {
 		log.Error("When search supported dock resource:", err)
 		return nil, err
@@ -86,7 +109,7 @@ func (c *Controller) CreateVolume(in *model.VolumeSpec) (*model.VolumeSpec, erro
 		Description:      in.GetDescription(),
 		Size:             in.GetSize(),
 		AvailabilityZone: in.GetAvailabilityZone(),
-		ProfileId:        prfID,
+		ProfileId:        profile.GetId(),
 		PoolId:           polInfo.GetId(),
 		DockId:           dockInfo.GetId(),
 		DriverName:       dockInfo.GetDriverName(),
@@ -104,9 +127,9 @@ func (c *Controller) CreateVolume(in *model.VolumeSpec) (*model.VolumeSpec, erro
 }
 
 func (c *Controller) DeleteVolume(in *model.VolumeSpec) error {
-	prf, err := c.SelectProfile(in.GetProfileId())
+	prf, err := db.C.GetProfile(in.ProfileId)
 	if err != nil {
-		log.Error("when search profiles in db:", err)
+		log.Error("when search profile in db:", err)
 		return err
 	}
 
@@ -114,9 +137,9 @@ func (c *Controller) DeleteVolume(in *model.VolumeSpec) error {
 	c.policyController = policy.NewController(prf)
 	c.policyController.Setup(DELETE_LIFECIRCLE_FLAG)
 
-	dockInfo, err := c.SelectDock(in.GetId())
+	dockInfo, err := db.C.GetDockByPoolId(in.PoolId)
 	if err != nil {
-		log.Error("When search supported dock resource:", err)
+		log.Error("When search dock in db by pool id: ", err)
 		return err
 	}
 	c.policyController.SetDock(dockInfo)
@@ -141,7 +164,12 @@ func (c *Controller) DeleteVolume(in *model.VolumeSpec) error {
 }
 
 func (c *Controller) CreateVolumeAttachment(in *model.VolumeAttachmentSpec) (*model.VolumeAttachmentSpec, error) {
-	dockInfo, err := c.SelectDock(in.GetVolumeId())
+	volume, err := db.C.GetVolume(in.VolumeId)
+	if err != nil {
+		log.Error("Get volume failed in create volume attachment method: ", err)
+		return nil, err
+	}
+	dockInfo, err := db.C.GetDockByPoolId(volume.PoolId)
 	if err != nil {
 		log.Error("When search supported dock resource:", err)
 		return nil, err
@@ -171,7 +199,12 @@ func (c *Controller) UpdateVolumeAttachment(in *model.VolumeAttachmentSpec) (*mo
 }
 
 func (c *Controller) DeleteVolumeAttachment(in *model.VolumeAttachmentSpec) error {
-	dockInfo, err := c.SelectDock(in.GetVolumeId())
+	volume, err := db.C.GetVolume(in.VolumeId)
+	if err != nil {
+		log.Error("Get volume failed in create volume attachment method: ", err)
+		return err
+	}
+	dockInfo, err := db.C.GetDockByPoolId(volume.PoolId)
 	if err != nil {
 		log.Error("When search supported dock resource:", err)
 		return err
@@ -197,7 +230,13 @@ func (c *Controller) DeleteVolumeAttachment(in *model.VolumeAttachmentSpec) erro
 }
 
 func (c *Controller) CreateVolumeSnapshot(in *model.VolumeSnapshotSpec) (*model.VolumeSnapshotSpec, error) {
-	dockInfo, err := c.SelectDock(in.GetVolumeId())
+	volume, err := db.C.GetVolume(in.VolumeId)
+	if err != nil {
+		log.Error("Get volume failed in create volume attachment method: ", err)
+		return nil, err
+	}
+
+	dockInfo, err := db.C.GetDockByPoolId(volume.PoolId)
 	if err != nil {
 		log.Error("When search supported dock resource:", err)
 		return nil, err
@@ -217,7 +256,12 @@ func (c *Controller) CreateVolumeSnapshot(in *model.VolumeSnapshotSpec) (*model.
 }
 
 func (c *Controller) DeleteVolumeSnapshot(in *model.VolumeSnapshotSpec) error {
-	dockInfo, err := c.SelectDock(in.GetVolumeId())
+	volume, err := db.C.GetVolume(in.VolumeId)
+	if err != nil {
+		log.Error("Get volume failed in create volume attachment method: ", err)
+		return err
+	}
+	dockInfo, err := db.C.GetDockByPoolId(volume.PoolId)
 	if err != nil {
 		log.Error("When search supported dock resource:", err)
 		return err

--- a/pkg/controller/selector/filter.go
+++ b/pkg/controller/selector/filter.go
@@ -1,0 +1,205 @@
+// Copyright 2017 The OpenSDS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package selector
+
+import (
+	"errors"
+
+	"github.com/opensds/opensds/pkg/model"
+)
+
+type Filter interface {
+	Handle(request map[string]interface{}, pools []*model.StoragePoolSpec) ([]*model.StoragePoolSpec, error)
+}
+
+type AZFilter struct {
+	Next Filter
+}
+
+func (filter *AZFilter) Handle(request map[string]interface{}, pools []*model.StoragePoolSpec) ([]*model.StoragePoolSpec, error) {
+	availabilityZone, ok := request["availabilityZone"]
+	if !ok {
+		return nil, errors.New("The request doesn't contain availability zone property when filter pools in AZFilter.")
+	}
+
+	availablePools := []*model.StoragePoolSpec{}
+	for _, pool := range pools {
+		if availabilityZone == pool.AvailabilityZone {
+			availablePools = append(availablePools, pool)
+		}
+	}
+
+	if len(availablePools) == 0 {
+		return nil, errors.New("No available pools to meet user's availability zone requirement.")
+	} else if filter.Next != nil {
+		return filter.Next.Handle(request, availablePools)
+	}
+	return availablePools, nil
+}
+
+type CapacityFilter struct {
+	Next Filter
+}
+
+func (filter *CapacityFilter) Handle(request map[string]interface{}, pools []*model.StoragePoolSpec) ([]*model.StoragePoolSpec, error) {
+
+	size, ok := request["size"]
+	if !ok {
+		return nil, errors.New("The request doesn't contain size property when filter pools in CapacityFilter.")
+	}
+
+	availablePools := []*model.StoragePoolSpec{}
+	for _, pool := range pools {
+		if val, ok := size.(int64); ok {
+			if val <= pool.FreeCapacity {
+				availablePools = append(availablePools, pool)
+			}
+		} else {
+			return nil, errors.New("Invalid parameter when filter pools in CapacityFilter.")
+		}
+
+	}
+
+	if len(availablePools) == 0 {
+		return nil, errors.New("No available pools to meet user's capacity requirement.")
+	} else if filter.Next != nil {
+		return filter.Next.Handle(request, availablePools)
+	}
+	return availablePools, nil
+}
+
+type ThinFilter struct {
+	Next Filter
+}
+
+func (filter *ThinFilter) Handle(request map[string]interface{}, pools []*model.StoragePoolSpec) ([]*model.StoragePoolSpec, error) {
+
+	availablePools := []*model.StoragePoolSpec{}
+	thinRequired, ok := request["thin"]
+	if !ok {
+		availablePools = pools
+	} else {
+		for _, pool := range pools {
+			thinSupport, ok := pool.Parameters["thin"]
+			if !ok {
+				thinSupport = false
+			}
+
+			if thinRequired == thinSupport {
+				availablePools = append(availablePools, pool)
+			}
+		}
+	}
+
+	if len(availablePools) == 0 {
+		return nil, errors.New("No available pools to meet user's thin requirement.")
+	} else if filter.Next != nil {
+		return filter.Next.Handle(request, availablePools)
+	}
+	return availablePools, nil
+}
+
+type CompressFilter struct {
+	Next Filter
+}
+
+func (filter *CompressFilter) Handle(request map[string]interface{}, pools []*model.StoragePoolSpec) ([]*model.StoragePoolSpec, error) {
+
+	availablePools := []*model.StoragePoolSpec{}
+	compressRequired, ok := request["compress"]
+	if !ok {
+		availablePools = pools
+	} else {
+		for _, pool := range pools {
+			compressSupport, ok := pool.Parameters["compress"]
+			if !ok {
+				compressSupport = false
+			}
+
+			if compressRequired == compressSupport {
+				availablePools = append(availablePools, pool)
+			}
+		}
+	}
+
+	if len(availablePools) == 0 {
+		return nil, errors.New("No available pools to meet user's compress requirement.")
+	} else if filter.Next != nil {
+		return filter.Next.Handle(request, availablePools)
+	}
+	return availablePools, nil
+}
+
+type DedupeFilter struct {
+	Next Filter
+}
+
+func (filter *DedupeFilter) Handle(request map[string]interface{}, pools []*model.StoragePoolSpec) ([]*model.StoragePoolSpec, error) {
+
+	availablePools := []*model.StoragePoolSpec{}
+	dedupeRequired, ok := request["dedupe"]
+	if !ok {
+		availablePools = pools
+	} else {
+		for _, pool := range pools {
+			dedupeSupport, ok := pool.Parameters["dedupe"]
+			if !ok {
+				dedupeSupport = false
+			}
+
+			if dedupeRequired == dedupeSupport {
+				availablePools = append(availablePools, pool)
+			}
+		}
+	}
+
+	if len(availablePools) == 0 {
+		return nil, errors.New("No available pools to meet user's dedupe requirement.")
+	} else if filter.Next != nil {
+		return filter.Next.Handle(request, availablePools)
+	}
+	return availablePools, nil
+}
+
+type DiskTypeFilter struct {
+	Next Filter
+}
+
+func (filter *DiskTypeFilter) Handle(request map[string]interface{}, pools []*model.StoragePoolSpec) ([]*model.StoragePoolSpec, error) {
+
+	availablePools := []*model.StoragePoolSpec{}
+	diskTypeRequired, ok := request["diskType"]
+	if !ok {
+		availablePools = pools
+	} else {
+		for _, pool := range pools {
+			diskTypeSupport, ok := pool.Parameters["diskType"]
+			if !ok {
+				diskTypeSupport = false
+			}
+
+			if diskTypeRequired == diskTypeSupport {
+				availablePools = append(availablePools, pool)
+			}
+		}
+	}
+
+	if len(availablePools) == 0 {
+		return nil, errors.New("No available pools to meet user's diskType requirement.")
+	} else if filter.Next != nil {
+		return filter.Next.Handle(request, availablePools)
+	}
+	return availablePools, nil
+}

--- a/pkg/controller/selector/filter_test.go
+++ b/pkg/controller/selector/filter_test.go
@@ -1,0 +1,369 @@
+// Copyright 2017 The OpenSDS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+This module implements the policy-based scheduling by parsing storage
+profiles configured by admin.
+
+*/
+
+package selector
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/opensds/opensds/pkg/model"
+)
+
+func TestCapacityFilter(t *testing.T) {
+	fakePools := []*model.StoragePoolSpec{
+		&model.StoragePoolSpec{
+			FreeCapacity: int64(100),
+		},
+		&model.StoragePoolSpec{
+			FreeCapacity: int64(50),
+		},
+		&model.StoragePoolSpec{
+			FreeCapacity: int64(66),
+		},
+	}
+	testCases := []struct {
+		request  map[string]interface{}
+		pools    []*model.StoragePoolSpec
+		expected []*model.StoragePoolSpec
+	}{
+		{
+			request: map[string]interface{}{
+				"size": int64(66),
+			},
+			pools: fakePools,
+			expected: []*model.StoragePoolSpec{
+				&model.StoragePoolSpec{
+					FreeCapacity: int64(100),
+				},
+				&model.StoragePoolSpec{
+					FreeCapacity: int64(66),
+				},
+			},
+		},
+		{
+			request: map[string]interface{}{
+				"size": 101,
+			},
+			pools:    fakePools,
+			expected: nil,
+		},
+	}
+	filter := &CapacityFilter{}
+	for _, testCase := range testCases {
+		result, _ := filter.Handle(testCase.request, testCase.pools)
+		if !reflect.DeepEqual(result, testCase.expected) {
+			t.Errorf("Expected %v, get %v", testCase.expected, result)
+		}
+	}
+}
+
+func TestAZFilter(t *testing.T) {
+	fakePools := []*model.StoragePoolSpec{
+		&model.StoragePoolSpec{
+			AvailabilityZone: "az1",
+		},
+		&model.StoragePoolSpec{
+			AvailabilityZone: "az2",
+		},
+		&model.StoragePoolSpec{
+			AvailabilityZone: "az1",
+		},
+	}
+	testCases := []struct {
+		request  map[string]interface{}
+		pools    []*model.StoragePoolSpec
+		expected []*model.StoragePoolSpec
+	}{
+		{
+			request: map[string]interface{}{
+				"availabilityZone": "az1",
+			},
+			pools: fakePools,
+			expected: []*model.StoragePoolSpec{
+				&model.StoragePoolSpec{
+					AvailabilityZone: "az1",
+				},
+				&model.StoragePoolSpec{
+					AvailabilityZone: "az1",
+				},
+			},
+		},
+		{
+			request: map[string]interface{}{
+				"availabilityZone": "az3",
+			},
+			pools:    fakePools,
+			expected: nil,
+		},
+	}
+	filter := &AZFilter{}
+	for _, testCase := range testCases {
+		result, _ := filter.Handle(testCase.request, testCase.pools)
+		if !reflect.DeepEqual(result, testCase.expected) {
+			t.Errorf("Expected %v, get %v", testCase.expected, result)
+		}
+	}
+}
+
+func TestThinFilter(t *testing.T) {
+	fakePools := []*model.StoragePoolSpec{
+		&model.StoragePoolSpec{
+			Parameters: map[string]interface{}{
+				"thin": true,
+			},
+		},
+		&model.StoragePoolSpec{
+			Parameters: map[string]interface{}{
+				"thin": true,
+			},
+		},
+		&model.StoragePoolSpec{
+			Parameters: map[string]interface{}{
+				"thin": false,
+			},
+		},
+	}
+	testCases := []struct {
+		request  map[string]interface{}
+		pools    []*model.StoragePoolSpec
+		expected []*model.StoragePoolSpec
+	}{
+		{
+			request: map[string]interface{}{
+				"thin": true,
+			},
+			pools: fakePools,
+			expected: []*model.StoragePoolSpec{
+				&model.StoragePoolSpec{
+					Parameters: map[string]interface{}{
+						"thin": true,
+					},
+				},
+				&model.StoragePoolSpec{
+					Parameters: map[string]interface{}{
+						"thin": true,
+					},
+				},
+			},
+		},
+		{
+			request: map[string]interface{}{
+				"thin": false,
+			},
+			pools: fakePools,
+			expected: []*model.StoragePoolSpec{
+				&model.StoragePoolSpec{
+					Parameters: map[string]interface{}{
+						"thin": false,
+					},
+				},
+			},
+		},
+	}
+	filter := &ThinFilter{}
+	for _, testCase := range testCases {
+		result, _ := filter.Handle(testCase.request, testCase.pools)
+		if !reflect.DeepEqual(result, testCase.expected) {
+			t.Errorf("Expected %v, get %v", testCase.expected, result)
+		}
+	}
+}
+
+func TestDedupeFilter(t *testing.T) {
+	fakePools := []*model.StoragePoolSpec{
+		&model.StoragePoolSpec{
+			Parameters: map[string]interface{}{
+				"dedupe": true,
+			},
+		},
+		&model.StoragePoolSpec{
+			Parameters: map[string]interface{}{
+				"dedupe": true,
+			},
+		},
+		&model.StoragePoolSpec{
+			Parameters: map[string]interface{}{
+				"dedupe": false,
+			},
+		},
+	}
+	testCases := []struct {
+		request  map[string]interface{}
+		pools    []*model.StoragePoolSpec
+		expected []*model.StoragePoolSpec
+	}{
+		{
+			request: map[string]interface{}{
+				"dedupe": true,
+			},
+			pools: fakePools,
+			expected: []*model.StoragePoolSpec{
+				&model.StoragePoolSpec{
+					Parameters: map[string]interface{}{
+						"dedupe": true,
+					},
+				},
+				&model.StoragePoolSpec{
+					Parameters: map[string]interface{}{
+						"dedupe": true,
+					},
+				},
+			},
+		},
+		{
+			request: map[string]interface{}{
+				"dedupe": false,
+			},
+			pools: fakePools,
+			expected: []*model.StoragePoolSpec{
+				&model.StoragePoolSpec{
+					Parameters: map[string]interface{}{
+						"dedupe": false,
+					},
+				},
+			},
+		},
+	}
+	filter := &DedupeFilter{}
+	for _, testCase := range testCases {
+		result, _ := filter.Handle(testCase.request, testCase.pools)
+		if !reflect.DeepEqual(result, testCase.expected) {
+			t.Errorf("Expected %v, get %v", testCase.expected, result)
+		}
+	}
+}
+
+func TestCompressFilter(t *testing.T) {
+	fakePools := []*model.StoragePoolSpec{
+		&model.StoragePoolSpec{
+			Parameters: map[string]interface{}{
+				"compress": true,
+			},
+		},
+		&model.StoragePoolSpec{
+			Parameters: map[string]interface{}{
+				"compress": true,
+			},
+		},
+		&model.StoragePoolSpec{
+			Parameters: map[string]interface{}{
+				"compress": false,
+			},
+		},
+	}
+	testCases := []struct {
+		request  map[string]interface{}
+		pools    []*model.StoragePoolSpec
+		expected []*model.StoragePoolSpec
+	}{
+		{
+			request: map[string]interface{}{
+				"compress": true,
+			},
+			pools: fakePools,
+			expected: []*model.StoragePoolSpec{
+				&model.StoragePoolSpec{
+					Parameters: map[string]interface{}{
+						"compress": true,
+					},
+				},
+				&model.StoragePoolSpec{
+					Parameters: map[string]interface{}{
+						"compress": true,
+					},
+				},
+			},
+		},
+		{
+			request: map[string]interface{}{
+				"compress": false,
+			},
+			pools: fakePools,
+			expected: []*model.StoragePoolSpec{
+				&model.StoragePoolSpec{
+					Parameters: map[string]interface{}{
+						"compress": false,
+					},
+				},
+			},
+		},
+	}
+	filter := &CompressFilter{}
+	for _, testCase := range testCases {
+		result, _ := filter.Handle(testCase.request, testCase.pools)
+		if !reflect.DeepEqual(result, testCase.expected) {
+			t.Errorf("Expected %v, get %v", testCase.expected, result)
+		}
+	}
+}
+
+func TestDiskTypeFilter(t *testing.T) {
+	fakePools := []*model.StoragePoolSpec{
+		&model.StoragePoolSpec{
+			Parameters: map[string]interface{}{
+				"diskType": "SSD",
+			},
+		},
+		&model.StoragePoolSpec{
+			Parameters: map[string]interface{}{
+				"diskType": "SAS",
+			},
+		},
+		&model.StoragePoolSpec{
+			Parameters: map[string]interface{}{
+				"diskType": "SATA",
+			},
+		},
+	}
+	testCases := []struct {
+		request  map[string]interface{}
+		pools    []*model.StoragePoolSpec
+		expected []*model.StoragePoolSpec
+	}{
+		{
+			request: map[string]interface{}{
+				"diskType": "SSD",
+			},
+			pools: fakePools,
+			expected: []*model.StoragePoolSpec{
+				&model.StoragePoolSpec{
+					Parameters: map[string]interface{}{
+						"diskType": "SSD",
+					},
+				},
+			},
+		},
+		{
+			request: map[string]interface{}{
+				"diskType": "NVMe SSD",
+			},
+			pools:    fakePools,
+			expected: nil,
+		},
+	}
+	filter := &DiskTypeFilter{}
+	for _, testCase := range testCases {
+		result, _ := filter.Handle(testCase.request, testCase.pools)
+		if !reflect.DeepEqual(result, testCase.expected) {
+			t.Errorf("Expected %v, get %v", testCase.expected, result)
+		}
+	}
+}

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -58,6 +58,8 @@ type Client interface {
 
 	DeleteDock(dckID string) error
 
+	GetDockByPoolId(poolId string) (*model.DockSpec, error)
+
 	CreatePool(pol *model.StoragePoolSpec) error
 
 	GetPool(polID string) (*model.StoragePoolSpec, error)
@@ -71,6 +73,8 @@ type Client interface {
 	CreateProfile(prf *model.ProfileSpec) error
 
 	GetProfile(prfID string) (*model.ProfileSpec, error)
+
+	GetDefaultProfile() (*model.ProfileSpec, error)
 
 	ListProfiles() ([]*model.ProfileSpec, error)
 

--- a/pkg/db/drivers/etcd/etcd.go
+++ b/pkg/db/drivers/etcd/etcd.go
@@ -97,6 +97,26 @@ func (c *client) GetDock(dckID string) (*model.DockSpec, error) {
 	return dck, nil
 }
 
+func (c *client) GetDockByPoolId(poolId string) (*model.DockSpec, error) {
+	pool, err := c.GetPool(poolId)
+	if err != nil {
+		log.Error("Get pool failed in db: ", err)
+		return nil, err
+	}
+
+	docks, err := c.ListDocks()
+	if err != nil {
+		log.Error("List docks failed failed in db: ", err)
+		return nil, err
+	}
+	for _, dock := range docks {
+		if pool.DockId == dock.Id {
+			return dock, nil
+		}
+	}
+	return nil, errors.New("Get dock failed by pool id: " + poolId)
+}
+
 func (c *client) ListDocks() ([]*model.DockSpec, error) {
 	dbReq := &Request{
 		Url: GenerateUrl(prefix, "docks"),
@@ -299,6 +319,21 @@ func (c *client) GetProfile(prfID string) (*model.ProfileSpec, error) {
 		return nil, errors.New(dbRes.Error)
 	}
 	return prf, nil
+}
+
+func (c *client) GetDefaultProfile() (*model.ProfileSpec, error) {
+	profiles, err := c.ListProfiles()
+	if err != nil {
+		log.Error("Get default profile failed in db: ", err)
+		return nil, err
+	}
+
+	for _, profile := range profiles {
+		if profile.Name == "default" {
+			return profile, nil
+		}
+	}
+	return nil, errors.New("No default profile in db.")
 }
 
 func (c *client) ListProfiles() ([]*model.ProfileSpec, error) {

--- a/testutils/db/fake.go
+++ b/testutils/db/fake.go
@@ -39,6 +39,18 @@ func (fc *FakeDbClient) GetDock(dckID string) (*model.DockSpec, error) {
 
 	return nil, errors.New("Can't find this dock resource!")
 }
+func (fc *FakeDbClient) GetDockByPoolId(poolId string) (*model.DockSpec, error) {
+	pool, err := fc.GetPool(poolId)
+	if err != nil {
+		return nil, err
+	}
+	for _, dock := range sampleDocks {
+		if dock.Id == pool.DockId {
+			return &dock, nil
+		}
+	}
+	return nil, errors.New("Can't find this dock resource by pool id!")
+}
 
 func (fc *FakeDbClient) ListDocks() ([]*model.DockSpec, error) {
 	var dcks []*model.DockSpec
@@ -100,6 +112,16 @@ func (fc *FakeDbClient) GetProfile(prfID string) (*model.ProfileSpec, error) {
 	}
 
 	return nil, errors.New("Can't find this profile resource!")
+}
+
+func (fc *FakeDbClient) GetDefaultProfile() (*model.ProfileSpec, error) {
+	for i := range sampleProfiles {
+		if sampleProfiles[i].Name == "default" {
+			return &sampleProfiles[i], nil
+		}
+	}
+
+	return nil, errors.New("Can't find default profile resource!")
 }
 
 func (fc *FakeDbClient) ListProfiles() ([]*model.ProfileSpec, error) {
@@ -235,11 +257,12 @@ var (
 			BaseModel: &model.BaseModel{
 				Id: "084bf71e-a102-11e7-88a8-e31fe6d52248",
 			},
-			Name:          "sample-pool-01",
-			Description:   "This is the first sample storage pool for testing",
-			TotalCapacity: int64(100),
-			FreeCapacity:  int64(90),
-			DockId:        "b7602e18-771e-11e7-8f38-dbd6d291f4e0",
+			Name:             "sample-pool-01",
+			Description:      "This is the first sample storage pool for testing",
+			TotalCapacity:    int64(100),
+			FreeCapacity:     int64(90),
+			DockId:           "b7602e18-771e-11e7-8f38-dbd6d291f4e0",
+			AvailabilityZone: "default",
 			Parameters: map[string]interface{}{
 				"diskType":  "SSD",
 				"iops":      1000,
@@ -250,11 +273,12 @@ var (
 			BaseModel: &model.BaseModel{
 				Id: "a594b8ac-a103-11e7-985f-d723bcf01b5f",
 			},
-			Name:          "sample-pool-02",
-			Description:   "This is the second sample storage pool for testing",
-			TotalCapacity: int64(200),
-			FreeCapacity:  int64(170),
-			DockId:        "b7602e18-771e-11e7-8f38-dbd6d291f4e0",
+			Name:             "sample-pool-02",
+			Description:      "This is the second sample storage pool for testing",
+			TotalCapacity:    int64(200),
+			FreeCapacity:     int64(170),
+			AvailabilityZone: "default",
+			DockId:           "b7602e18-771e-11e7-8f38-dbd6d291f4e0",
 			Parameters: map[string]interface{}{
 				"diskType":  "SAS",
 				"iops":      800,

--- a/testutils/db/testing/mock_db.go
+++ b/testutils/db/testing/mock_db.go
@@ -232,6 +232,28 @@ func (_m *MockClient) GetDock(dckID string) (*model.DockSpec, error) {
 	return r0, r1
 }
 
+func (_m *MockClient) GetDockByPoolId(poolId string) (*model.DockSpec, error) {
+	ret := _m.Called(poolId)
+
+	var r0 *model.DockSpec
+	if rf, ok := ret.Get(0).(func(string) *model.DockSpec); ok {
+		r0 = rf(poolId)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.DockSpec)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(poolId)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 func (_m *MockClient) GetPool(polID string) (*model.StoragePoolSpec, error) {
 	ret := _m.Called(polID)
 
@@ -269,6 +291,28 @@ func (_m *MockClient) GetProfile(prfID string) (*model.ProfileSpec, error) {
 	var r1 error
 	if rf, ok := ret.Get(1).(func(string) error); ok {
 		r1 = rf(prfID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+func (_m *MockClient) GetDefaultProfile() (*model.ProfileSpec, error) {
+	ret := _m.Called()
+
+	var r0 *model.ProfileSpec
+	if rf, ok := ret.Get(0).(func() *model.ProfileSpec); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.ProfileSpec)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
 	} else {
 		r1 = ret.Error(1)
 	}


### PR DESCRIPTION
### Background
As we know, the core feature of opensds is how to filter the virtual pools by user's profile and select the most suitable pool to allocate resources. So, I added the alpha design and implementation that may be changed or improved in the future.

### Changes
1. Add the capacity and availability zone filters, both are required in every request.
2. Add optional filters, suce disk type, thin, compress and dedupe, etc.
3. Add db interface, such as `GetDefaultProfile`, `GetDockByPoold` instead of these method in `Selector`. And the `Selector` interface will focus on how to filter virtual pools.