### PR TITLE
Update unit test of lvm and cinder driver

### DIFF
--- a/contrib/drivers/lvm/lvm_test.go
+++ b/contrib/drivers/lvm/lvm_test.go
@@ -35,6 +35,7 @@ func TestSetup(t *testing.T) {
 					DiskType:  "SSD",
 					IOPS:      int64(1000),
 					BandWidth: int64(1000),
+					AZ:        "default",
 				},
 			},
 		},

--- a/contrib/drivers/openstack/cinder/cinder_test.go
+++ b/contrib/drivers/openstack/cinder/cinder_test.go
@@ -83,6 +83,9 @@ func TestSetup(t *testing.T) {
 	if d.conf.Pool["pool1"].BandWidth != 1000 {
 		t.Error("Test config pool1 BandWidth error")
 	}
+	if d.conf.Pool["pool1"].AZ != "nova-01" {
+		t.Error("Test config pool1 AZ error")
+	}
 
 	if d.conf.Pool["pool2"].DiskType != "SAS" {
 		t.Error("Test config pool2 DiskType error")
@@ -92,6 +95,9 @@ func TestSetup(t *testing.T) {
 	}
 	if d.conf.Pool["pool2"].BandWidth != 800 {
 		t.Error("Test config pool2 BandWidth error")
+	}
+	if d.conf.Pool["pool2"].AZ != "nova-02" {
+		t.Error("Test config pool2 AZ error")
 	}
 }
 

--- a/contrib/drivers/openstack/cinder/testdata/cinder.yaml
+++ b/contrib/drivers/openstack/cinder/testdata/cinder.yaml
@@ -11,7 +11,9 @@ pool:
     diskType: SSD
     iops: 1000
     bandwidth: 1000
+    AZ: nova-01
   pool2:
     diskType: SAS
     iops: 800
     bandwidth: 800
+    AZ: nova-02

--- a/contrib/drivers/utils/config/config_test.go
+++ b/contrib/drivers/utils/config/config_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2017 OpenSDS Authors.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License"); you may
+//    not use this file except in compliance with the License. You may obtain
+//    a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+//    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+//    License for the specific language governing permissions and limitations
+//    under the License.
+
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+type Config struct {
+	ConfigFile string                    `yaml:"configFile,omitempty"`
+	Pool       map[string]PoolProperties `yaml:"pool,flow"`
+}
+
+func TestParse(t *testing.T) {
+	var conf, path = &Config{}, "testdata/config.yaml"
+	var expectedConfig = &Config{
+		ConfigFile: "/etc/ceph/ceph.conf",
+		Pool: map[string]PoolProperties{
+			"rbd": {
+				DiskType:  "SSD",
+				IOPS:      int64(1000),
+				BandWidth: int64(1000),
+				AZ:        "ceph",
+			},
+		},
+	}
+
+	result, err := Parse(conf, path)
+	if err != nil {
+		t.Errorf("Failed to parse path %s to Config struct: %v\n", path, err)
+	}
+	if !reflect.DeepEqual(result, expectedConfig) {
+		t.Errorf("Expected %+v, got %+v\n", expectedConfig, result)
+	}
+}

--- a/contrib/drivers/utils/config/testdata/config.yaml
+++ b/contrib/drivers/utils/config/testdata/config.yaml
@@ -1,6 +1,7 @@
+configFile: /etc/ceph/ceph.conf
 pool:
-  "vg001":
+  "rbd":
     diskType: SSD
     iops: 1000
     bandwidth: 1000
-    AZ: default
+    AZ: ceph


### PR DESCRIPTION
In this patch, ```TestSetup``` function in lvm and cinder driver are updated, and some unit tests in driver config module are added.