### PR TITLE
Update dock client interface methods

### DIFF
--- a/pkg/controller/policy/executor/executordeletesnapshot.go
+++ b/pkg/controller/policy/executor/executordeletesnapshot.go
@@ -54,7 +54,7 @@ func (dse *DeleteSnapshotExecutor) Init(in string) (err error) {
 	}
 	dse.VolumeId = volumeResponse.Id
 	dse.Client = client.NewClient()
-	dse.Client.Update(dse.DockInfo)
+	dse.Client.Connect(dse.DockInfo.Endpoint)
 
 	return nil
 }

--- a/pkg/controller/policy/executor/executorintervalsnapshot.go
+++ b/pkg/controller/policy/executor/executorintervalsnapshot.go
@@ -54,7 +54,7 @@ func (ise *IntervalSnapshotExecutor) Init(in string) (err error) {
 	ise.Request.Name = "snapshot-" + volumeResponse.Id
 	ise.Request.Size = volumeResponse.Size
 	ise.Client = client.NewClient()
-	ise.Client.Update(ise.DockInfo)
+	ise.Client.Connect(ise.DockInfo.Endpoint)
 
 	return nil
 }

--- a/pkg/controller/volume/volumecontroller.go
+++ b/pkg/controller/volume/volumecontroller.go
@@ -60,8 +60,8 @@ type controller struct {
 }
 
 func (c *controller) CreateVolume(opt *pb.CreateVolumeOpts) (*model.VolumeSpec, error) {
-	if err := c.Client.Update(c.DockInfo); err != nil {
-		log.Error("When parsing dock info:", err)
+	if err := c.Client.Connect(c.DockInfo.Endpoint); err != nil {
+		log.Error("When connecting dock client:", err)
 		return nil, err
 	}
 
@@ -89,8 +89,8 @@ func (c *controller) CreateVolume(opt *pb.CreateVolumeOpts) (*model.VolumeSpec, 
 }
 
 func (c *controller) DeleteVolume(opt *pb.DeleteVolumeOpts) error {
-	if err := c.Client.Update(c.DockInfo); err != nil {
-		log.Error("When parsing dock info:", err)
+	if err := c.Client.Connect(c.DockInfo.Endpoint); err != nil {
+		log.Error("When connecting dock client:", err)
 		return err
 	}
 
@@ -109,8 +109,8 @@ func (c *controller) DeleteVolume(opt *pb.DeleteVolumeOpts) error {
 }
 
 func (c *controller) CreateVolumeAttachment(opt *pb.CreateAttachmentOpts) (*model.VolumeAttachmentSpec, error) {
-	if err := c.Client.Update(c.DockInfo); err != nil {
-		log.Error("When parsing dock info:", err)
+	if err := c.Client.Connect(c.DockInfo.Endpoint); err != nil {
+		log.Error("When connecting dock client:", err)
 		return nil, err
 	}
 
@@ -137,8 +137,8 @@ func (c *controller) CreateVolumeAttachment(opt *pb.CreateAttachmentOpts) (*mode
 }
 
 func (c *controller) DeleteVolumeAttachment(opt *pb.DeleteAttachmentOpts) error {
-	if err := c.Client.Update(c.DockInfo); err != nil {
-		log.Error("When parsing dock info:", err)
+	if err := c.Client.Connect(c.DockInfo.Endpoint); err != nil {
+		log.Error("When connecting dock client:", err)
 		return err
 	}
 
@@ -157,8 +157,8 @@ func (c *controller) DeleteVolumeAttachment(opt *pb.DeleteAttachmentOpts) error 
 }
 
 func (c *controller) CreateVolumeSnapshot(opt *pb.CreateVolumeSnapshotOpts) (*model.VolumeSnapshotSpec, error) {
-	if err := c.Client.Update(c.DockInfo); err != nil {
-		log.Error("When parsing dock info:", err)
+	if err := c.Client.Connect(c.DockInfo.Endpoint); err != nil {
+		log.Error("When connecting dock client:", err)
 		return nil, err
 	}
 
@@ -185,8 +185,8 @@ func (c *controller) CreateVolumeSnapshot(opt *pb.CreateVolumeSnapshotOpts) (*mo
 }
 
 func (c *controller) DeleteVolumeSnapshot(opt *pb.DeleteVolumeSnapshotOpts) error {
-	if err := c.Client.Update(c.DockInfo); err != nil {
-		log.Error("When parsing dock info:", err)
+	if err := c.Client.Connect(c.DockInfo.Endpoint); err != nil {
+		log.Error("When connecting dock client:", err)
 		return err
 	}
 

--- a/pkg/controller/volume/volumecontroller_test.go
+++ b/pkg/controller/volume/volumecontroller_test.go
@@ -26,17 +26,13 @@ import (
 	"google.golang.org/grpc"
 )
 
-type fakeClient struct {
-	TargetPlace string
+type fakeClient struct{}
+
+func NewFakeClient() client.Client {
+	return &fakeClient{}
 }
 
-func NewFakeClient(address string) client.Client {
-	return &fakeClient{
-		TargetPlace: address,
-	}
-}
-
-func (fc *fakeClient) Update(dockInfo *model.DockSpec) error {
+func (fc *fakeClient) Connect(edp string) error {
 	return nil
 }
 
@@ -111,13 +107,13 @@ func (fc *fakeClient) DeleteVolumeSnapshot(ctx context.Context, in *pb.DeleteVol
 
 func NewFakeController() Controller {
 	return &controller{
-		Client: NewFakeClient(""),
-		//Request: req,
+		Client:   NewFakeClient(),
+		DockInfo: &model.DockSpec{},
 	}
 }
 
 func TestCreateVolume(t *testing.T) {
-	fc := NewFakeController( /*&pb.DockRequest{}*/ )
+	fc := NewFakeController()
 	var expected = &sampleVolume
 
 	result, err := fc.CreateVolume(&pb.CreateVolumeOpts{})
@@ -131,7 +127,7 @@ func TestCreateVolume(t *testing.T) {
 }
 
 func TestDeleteVolume(t *testing.T) {
-	fc := NewFakeController( /*&pb.DockRequest{}*/ )
+	fc := NewFakeController()
 
 	result := fc.DeleteVolume(&pb.DeleteVolumeOpts{})
 	if result != nil {
@@ -140,7 +136,7 @@ func TestDeleteVolume(t *testing.T) {
 }
 
 func TestCreateVolumeAttachment(t *testing.T) {
-	fc := NewFakeController( /*&pb.DockRequest{}*/ )
+	fc := NewFakeController()
 	var expected = &sampleAttachment
 
 	result, err := fc.CreateVolumeAttachment(&pb.CreateAttachmentOpts{})
@@ -154,7 +150,7 @@ func TestCreateVolumeAttachment(t *testing.T) {
 }
 
 func TestDeleteVolumeAttachment(t *testing.T) {
-	fc := NewFakeController( /*&pb.DockRequest{}*/ )
+	fc := NewFakeController()
 
 	result := fc.DeleteVolumeAttachment(&pb.DeleteAttachmentOpts{})
 	if result != nil {
@@ -163,7 +159,7 @@ func TestDeleteVolumeAttachment(t *testing.T) {
 }
 
 func TestCreateVolumeSnapshot(t *testing.T) {
-	fc := NewFakeController( /*&pb.DockRequest{}*/ )
+	fc := NewFakeController()
 	var expected = &sampleSnapshot
 
 	result, err := fc.CreateVolumeSnapshot(&pb.CreateVolumeSnapshotOpts{})
@@ -177,7 +173,7 @@ func TestCreateVolumeSnapshot(t *testing.T) {
 }
 
 func TestDeleteVolumeSnapshot(t *testing.T) {
-	fc := NewFakeController( /*&pb.DockRequest{}*/ )
+	fc := NewFakeController()
 
 	result := fc.DeleteVolumeSnapshot(&pb.DeleteVolumeSnapshotOpts{})
 	if result != nil {


### PR DESCRIPTION
In this patch, some mehods in ```Client``` interface are modified to make it more clear about how to connect dock client.