### PR TITLE
Fxied update attachment metadata nil bug

### DIFF
--- a/pkg/db/drivers/etcd/etcd.go
+++ b/pkg/db/drivers/etcd/etcd.go
@@ -684,6 +684,9 @@ func (c *Client) UpdateVolumeAttachment(attachmentId string, attachment *model.V
 		result.DriverVolumeType = attachment.DriverVolumeType
 	}
 	// Update metadata
+	if result.Metadata == nil {
+		result.Metadata = make(map[string]string)
+	}
 	for k, v := range attachment.Metadata {
 		result.Metadata[k] = v
 	}


### PR DESCRIPTION
Fxied update attachment metadata nil bug.
If the attachment metadata was not used bofore the metadata is a nil map, so we need init it firtly.