### PR TITLE
Change the store place to /opt directory to avoid conflict with ceph …

### DIFF
--- a/contrib/ansible/group_vars/common.yml
+++ b/contrib/ansible/group_vars/common.yml
@@ -15,7 +15,7 @@ dummy:
 # GENERAL #
 ###########
 
-workplace: /home/krej # Change this field according to your username
+workplace: /home/krej # Change this field according to your username, use '/root' if you login as root.
 
 # These fields are NOT suggested to be modified
 remote_url: https://github.com/opensds/opensds.git

--- a/contrib/ansible/group_vars/osdsdb.yml
+++ b/contrib/ansible/group_vars/osdsdb.yml
@@ -28,4 +28,4 @@ etcd_release: v3.2.0
 # These fields are not suggested to be modified
 etcd_tarball: etcd-{{ etcd_release }}-linux-amd64.tar.gz
 etcd_download_url: https://github.com/coreos/etcd/releases/download/{{ etcd_release }}/{{ etcd_tarball }}
-etcd_dir: /tmp/etcd-{{ etcd_release }}-linux-amd64
+etcd_dir: /opt/etcd-{{ etcd_release }}-linux-amd64

--- a/contrib/ansible/roles/cleaner/tasks/main.yml
+++ b/contrib/ansible/roles/cleaner/tasks/main.yml
@@ -14,7 +14,7 @@
 
 - name: remove etcd tarball
   file:
-    path: "/tmp/{{ etcd_tarball }}"
+    path: "/opt/{{ etcd_tarball }}"
     state: absent
     force: yes
   ignore_errors: yes

--- a/contrib/ansible/roles/osdsdb/scenarios/etcd.yml
+++ b/contrib/ansible/roles/osdsdb/scenarios/etcd.yml
@@ -8,14 +8,14 @@
 - name: download etcd
   get_url:
     url={{ etcd_download_url }}
-    dest=/tmp/{{ etcd_tarball }}
+    dest=/opt/{{ etcd_tarball }}
   when:
     - etcdexisted.stat.exists is undefined or etcdexisted.stat.exists == false
 
 - name: extract the etcd tarball
   unarchive:
-    src=/tmp/{{ etcd_tarball }}
-    dest=/tmp/
+    src=/opt/{{ etcd_tarball }}
+    dest=/opt/
   when:
     - etcdexisted.stat.exists is undefined or etcdexisted.stat.exists == false
 

--- a/contrib/ansible/roles/osdsdock/scenarios/ceph.yml
+++ b/contrib/ansible/roles/osdsdock/scenarios/ceph.yml
@@ -6,48 +6,48 @@
 
 - name: check for ceph-ansible source code existed
   stat:
-    path: /tmp/ceph-ansible
+    path: /opt/ceph-ansible
   ignore_errors: yes
   register: cephansibleexisted
 
 - name: download ceph-ansible source code
   git:
     repo: https://github.com/ceph/ceph-ansible.git
-    dest: /tmp/ceph-ansible
+    dest: /opt/ceph-ansible
   when:
     - cephansibleexisted.stat.exists is undefined or cephansibleexisted.stat.exists == false
 
 - name: copy ceph inventory host into ceph-ansible directory
   copy:
     src: ../../../group_vars/ceph/ceph.hosts
-    dest: /tmp/ceph-ansible/ceph.hosts
+    dest: /opt/ceph-ansible/ceph.hosts
 
 - name: copy ceph all.yml file into ceph-ansible group_vars directory
   copy:
     src: ../../../group_vars/ceph/all.yml
-    dest: /tmp/ceph-ansible/group_vars/all.yml
+    dest: /opt/ceph-ansible/group_vars/all.yml
 
 - name: copy ceph osds.yml file into ceph-ansible group_vars directory
   copy:
     src: ../../../group_vars/ceph/osds.yml
-    dest: /tmp/ceph-ansible/group_vars/osds.yml
+    dest: /opt/ceph-ansible/group_vars/osds.yml
 
 - name: copy site.yml.sample to site.yml in ceph-ansible
   copy:
-    src: /tmp/ceph-ansible/site.yml.sample
-    dest: /tmp/ceph-ansible/site.yml
+    src: /opt/ceph-ansible/site.yml.sample
+    dest: /opt/ceph-ansible/site.yml
 
 - name: ping all hosts
   shell: ansible all -m ping -i ceph.hosts
   become: true
   args:
-    chdir: /tmp/ceph-ansible
+    chdir: /opt/ceph-ansible
 
 - name: run ceph-ansible playbook
   shell: ansible-playbook site.yml -i ceph.hosts
   become: true
   args:
-    chdir: /tmp/ceph-ansible
+    chdir: /opt/ceph-ansible
 
 - name: Check if ceph osd is running
   shell: ps aux | grep ceph-osd | grep -v grep


### PR DESCRIPTION
…ansible

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Change the store dir of downloaded files from ```/tmp``` to ```/opt``` dir.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Currently ceph-ansible tool stores all dependencies in ```/tmp``` dir, but it would purge all files when user wants to purge the cluster, and it may delete some opensds dependencies by mistake. To avoid this situaiton, I suggest we change the download directory to ```/opt/```  to keep away from cpeh-ansible workplace.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
