### PR TITLE
Update docker-compose start script

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,12 +2,24 @@ version: '2'
 services:
   osdslet:
     image: 'opensdsio/opensds-controller:latest'
+    tty: true
     network_mode: "host"
     volumes:
     - /etc/opensds:/etc/opensds
+    depends_on:
+    - osdsdb
   osdsdock:
     image: 'opensdsio/opensds-dock:latest'
+    tty: true
     network_mode: "host"
     privileged: true
     volumes:
     - /etc/opensds:/etc/opensds
+    depends_on:
+    - osdsdb
+  osdsdb:
+    image: 'quay.io/coreos/etcd:latest'
+    tty: true
+    network_mode: "host"
+    volumes:
+    - /usr/share/ca-certificates/:/etc/ssl/certs

--- a/testutils/collection/data.go
+++ b/testutils/collection/data.go
@@ -338,7 +338,7 @@ var (
 		"updatedAt": "2017-04-10T14:36:58.014Z"
 	}`
 
-	ByteVersions= `[
+	ByteVersions = `[
 		{
 			"name": "v1beta",
 			"status": "CURRENT",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add etcd start-up script in docker-compose file so that we can create a standalone opensds cluster in one command.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
