### PR TITLE
delete osdsctl volume snapshot required parameter volume id, and add opetimize the lvm log info printing

### DIFF
--- a/contrib/drivers/lvm/lvm.go
+++ b/contrib/drivers/lvm/lvm.go
@@ -322,7 +322,6 @@ func (d *Driver) getVGList() (*[]VolumeGroup, error) {
 		return nil, err
 	}
 
-	log.Info("Got vgs info:", info)
 	lines := strings.Split(info, "\n")
 	vgs := make([]VolumeGroup, len(lines)/vgInfoLineCount)
 
@@ -388,10 +387,12 @@ func (*Driver) buildPoolParam(proper PoolProperties) *map[string]interface{} {
 }
 
 func execCmd(script string, cmd []string) (string, error) {
+	log.Infof("Command: %s %s", script, strings.Join(cmd, " "))
 	ret, err := exec.Command(script, cmd...).Output()
 	if err != nil {
 		log.Error(err.Error())
 		return "", err
 	}
+	log.Infof("Command Result:\n%s", string(ret))
 	return string(ret), nil
 }

--- a/osdsctl/cli/volumesnapshot.go
+++ b/osdsctl/cli/volumesnapshot.go
@@ -52,7 +52,7 @@ var volumeSnapshotListCommand = &cobra.Command{
 }
 
 var volumeSnapshotDeleteCommand = &cobra.Command{
-	Use:   "delete <volume id> <snapshot id>",
+	Use:   "delete <snapshot id>",
 	Short: "delete a volume snapshot of specified volume in the cluster",
 	Run:   volumeSnapshotDeleteAction,
 }
@@ -140,20 +140,18 @@ func volumeSnapshotListAction(cmd *cobra.Command, args []string) {
 }
 
 func volumeSnapshotDeleteAction(cmd *cobra.Command, args []string) {
-	if len(args) != 2 {
+	if len(args) != 1 {
 		fmt.Fprintln(os.Stderr, "The number of args is not correct!")
 		cmd.Usage()
 		os.Exit(1)
 	}
-	snp := &model.VolumeSnapshotSpec{
-		VolumeId: args[0],
-	}
-	err := client.DeleteVolumeSnapshot(args[1], snp)
+	snapID := args[0]
+	err := client.DeleteVolumeSnapshot(snapID, nil)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
-	fmt.Printf("Delete snapshot(%s) success.\n", args[1])
+	fmt.Printf("Delete snapshot(%s) success.\n", snapID)
 }
 
 func volumeSnapshotUpdateAction(cmd *cobra.Command, args []string) {

--- a/osdsctl/cli/volumesnapshot_test.go
+++ b/osdsctl/cli/volumesnapshot_test.go
@@ -69,7 +69,6 @@ func TestVolumeSnapshotListAction(t *testing.T) {
 
 func TestVolumeSnapshotDeleteAction(t *testing.T) {
 	var args []string
-	args = append(args, "bd5b12a8-a101-11e7-941e-d77981b584d8")
 	args = append(args, "3769855c-a102-11e7-b772-17b880d2f537")
 	volumeSnapshotDeleteAction(volumeSnapshotDeleteCommand, args)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. Delete osdsctl volume snapshot required parameter volume id
2. Add opetimize the lvm log info printing

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
#259 
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
