### PR TITLE
remove etcd server repeat parameter

### DIFF
--- a/contrib/ansible/roles/osdsdb/scenarios/etcd.yml
+++ b/contrib/ansible/roles/osdsdb/scenarios/etcd.yml
@@ -39,7 +39,7 @@
   register: service_etcd_status
 
 - name: run etcd daemon service
-  shell: nohup ./etcd --advertise-client-urls http://{{ etcd_host }}:{{ etcd_port }} --listen-client-urls http://{{ etcd_host }}:{{ etcd_port }} -advertise-client-urls http://{{ etcd_host }}:{{ etcd_peer_port }} -listen-peer-urls http://{{ etcd_host }}:{{ etcd_peer_port }} &>>etcd.log &
+  shell: nohup ./etcd --advertise-client-urls http://{{ etcd_host }}:{{ etcd_port }} --listen-client-urls http://{{ etcd_host }}:{{ etcd_port }}  --listen-peer-urls http://{{ etcd_host }}:{{ etcd_peer_port }} &>>etcd.log &
   become: true
   args:
     chdir: "{{ etcd_dir }}"

--- a/script/devsds/lib/etcd.sh
+++ b/script/devsds/lib/etcd.sh
@@ -35,8 +35,7 @@ osds::etcd::start() {
     # Start etcd
     mkdir -p $ETCD_DIR
     nohup etcd --advertise-client-urls http://${ETCD_HOST}:${ETCD_PORT} --listen-client-urls http://${ETCD_HOST}:${ETCD_PORT}\
-    -advertise-client-urls http://${ETCD_HOST}:${ETCD_PEER_PORT} -listen-peer-urls http://${ETCD_HOST}:${ETCD_PEER_PORT}\
-    --data-dir ${ETCD_DATADIR} --debug 2> "${ETCD_LOGFILE}" >/dev/null &
+    --listen-peer-urls http://${ETCD_HOST}:${ETCD_PEER_PORT} --data-dir ${ETCD_DATADIR} --debug 2> "${ETCD_LOGFILE}" >/dev/null &
     echo $! > $ETCD_DIR/etcd.pid
 
     osds::echo_summary "Waiting for etcd to come up."


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
when startup etcd server,  the first paramter `--advertise-client-urls`  is repeated with the third paramter, and this can cuase the command `etcdctl  cluster-health` goes wrong. so just remove it.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
