### PR TITLE
Make attachment print more pretty

### DIFF
--- a/osdsctl/cli/pool.go
+++ b/osdsctl/cli/pool.go
@@ -66,7 +66,7 @@ func poolShowAction(cmd *cobra.Command, args []string) {
 	}
 	keys := KeyList{"Id", "CreatedAt", "UpdatedAt", "Name", "Description", "Status", "DockId",
 		"AvailabilityZone", "TotalCapacity", "FreeCapacity", "StorageType", "Extras"}
-	PrintDict(pols, keys, FormatterList{})
+	PrintDict(pols, keys, FormatterList{"Extras": JsonFormatter})
 }
 
 func poolListAction(cmd *cobra.Command, args []string) {

--- a/osdsctl/cli/profile.go
+++ b/osdsctl/cli/profile.go
@@ -70,6 +70,8 @@ func profileAction(cmd *cobra.Command, args []string) {
 	os.Exit(1)
 }
 
+var profileFormatters = FormatterList{"Extras": JsonFormatter}
+
 func profileCreateAction(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
 		fmt.Fprintln(os.Stderr, "The number of args is not correct!")
@@ -90,7 +92,7 @@ func profileCreateAction(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 	keys := KeyList{"Id", "CreatedAt", "UpdatedAt", "Name", "Description", "Extras"}
-	PrintDict(resp, keys, FormatterList{})
+	PrintDict(resp, keys, profileFormatters)
 }
 
 func profileShowAction(cmd *cobra.Command, args []string) {
@@ -106,7 +108,7 @@ func profileShowAction(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 	keys := KeyList{"Id", "CreatedAt", "UpdatedAt", "Name", "Description", "Extras"}
-	PrintDict(resp, keys, FormatterList{})
+	PrintDict(resp, keys, profileFormatters)
 }
 
 func profileListAction(cmd *cobra.Command, args []string) {
@@ -121,7 +123,7 @@ func profileListAction(cmd *cobra.Command, args []string) {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
-	keys := KeyList{"Id", "Name", "Description", "Extras"}
+	keys := KeyList{"Id", "Name", "Description"}
 	PrintList(resp, keys, FormatterList{})
 }
 

--- a/osdsctl/cli/table.go
+++ b/osdsctl/cli/table.go
@@ -8,6 +8,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
@@ -34,6 +35,11 @@ type KeyList []string
 type StructElemCb func(name string, value reflect.Value) error
 
 var m = bd{'-', '|', '+', '+', '+', '+', '+', '+', '+', '+', '+'}
+
+func JsonFormatter(v interface{}) string {
+	b, _ := json.MarshalIndent(v, "", " ")
+	return string(b)
+}
 
 // Output formats slice of structs data and writes to standard output.(Using box drawing characters)
 func PrintList(slice interface{}, keys KeyList, fmts FormatterList) {

--- a/osdsctl/cli/table.go
+++ b/osdsctl/cli/table.go
@@ -195,14 +195,14 @@ func parseDict(u interface{}, keys KeyList, fmts FormatterList) (
 		bmHead := getHead(bm, keys)
 		bmRow := getRow(bm, keys, fmts)
 		for i := 0; i < len(bmHead); i++ {
-			rows = append(rows, []string{bmHead[i], bmRow[i]})
+			rows = appendRow(rows, []string{bmHead[i], bmRow[i]})
 		}
 	}
 
 	head := getHead(u, keys)
 	row := getRow(u, keys, fmts)
 	for i := 0; i < len(head); i++ {
-		rows = append(rows, []string{head[i], row[i]})
+		rows = appendRow(rows, []string{head[i], row[i]})
 	}
 	coln = []string{"Property", "Value"}
 	colw = getColw(coln, rows)

--- a/osdsctl/cli/volumeattachment.go
+++ b/osdsctl/cli/volumeattachment.go
@@ -77,6 +77,15 @@ func volumeAttachmentAction(cmd *cobra.Command, args []string) {
 	os.Exit(1)
 }
 
+var fmtList = FormatterList{"HostInfo": func(v interface{}) string {
+	b, _ := json.MarshalIndent(v, "", "  ")
+	return string(b)
+},
+	"ConnectionInfo": func(v interface{}) string {
+		b, _ := json.MarshalIndent(v, "", "  ")
+		return string(b)
+	}}
+
 func volumeAttachmentCreateAction(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
 		fmt.Fprintln(os.Stderr, "The number of args is not correct!")
@@ -98,7 +107,7 @@ func volumeAttachmentCreateAction(cmd *cobra.Command, args []string) {
 	}
 	keys := KeyList{"Id", "CreatedAt", "UpdatedAt", "TenantId", "UserId", "HostInfo", "ConnectionInfo",
 		"Mountpoint", "Status", "VolumeId"}
-	PrintDict(resp, keys, FormatterList{})
+	PrintDict(resp, keys, fmtList)
 }
 
 func volumeAttachmentShowAction(cmd *cobra.Command, args []string) {
@@ -115,7 +124,7 @@ func volumeAttachmentShowAction(cmd *cobra.Command, args []string) {
 	}
 	keys := KeyList{"Id", "CreatedAt", "UpdatedAt", "TenantId", "UserId", "HostInfo", "ConnectionInfo",
 		"Mountpoint", "Status", "VolumeId"}
-	PrintDict(resp, keys, FormatterList{})
+	PrintDict(resp, keys, fmtList)
 }
 
 func volumeAttachmentListAction(cmd *cobra.Command, args []string) {
@@ -130,9 +139,8 @@ func volumeAttachmentListAction(cmd *cobra.Command, args []string) {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
-	keys := KeyList{"Id", "TenantId", "UserId", "HostInfo", "ConnectionInfo",
-		"Mountpoint", "Status", "VolumeId"}
-	PrintList(resp, keys, FormatterList{})
+	keys := KeyList{"Id", "TenantId", "UserId", "Mountpoint", "Status", "VolumeId"}
+	PrintList(resp, keys, fmtList)
 }
 
 func volumeAttachmentDeleteAction(cmd *cobra.Command, args []string) {
@@ -173,5 +181,5 @@ func volumeAttachmentUpdateAction(cmd *cobra.Command, args []string) {
 	}
 	keys := KeyList{"Id", "CreatedAt", "UpdatedAt", "TenantId", "UserId", "HostInfo", "ConnectionInfo",
 		"Mountpoint", "Status", "VolumeId"}
-	PrintDict(resp, keys, FormatterList{})
+	PrintDict(resp, keys, fmtList)
 }

--- a/osdsctl/cli/volumeattachment.go
+++ b/osdsctl/cli/volumeattachment.go
@@ -77,14 +77,7 @@ func volumeAttachmentAction(cmd *cobra.Command, args []string) {
 	os.Exit(1)
 }
 
-var fmtList = FormatterList{"HostInfo": func(v interface{}) string {
-	b, _ := json.MarshalIndent(v, "", "  ")
-	return string(b)
-},
-	"ConnectionInfo": func(v interface{}) string {
-		b, _ := json.MarshalIndent(v, "", "  ")
-		return string(b)
-	}}
+var attachmentFormatters = FormatterList{"HostInfo": JsonFormatter, "ConnectionInfo": JsonFormatter}
 
 func volumeAttachmentCreateAction(cmd *cobra.Command, args []string) {
 	if len(args) != 1 {
@@ -107,7 +100,7 @@ func volumeAttachmentCreateAction(cmd *cobra.Command, args []string) {
 	}
 	keys := KeyList{"Id", "CreatedAt", "UpdatedAt", "TenantId", "UserId", "HostInfo", "ConnectionInfo",
 		"Mountpoint", "Status", "VolumeId"}
-	PrintDict(resp, keys, fmtList)
+	PrintDict(resp, keys, attachmentFormatters)
 }
 
 func volumeAttachmentShowAction(cmd *cobra.Command, args []string) {
@@ -124,7 +117,7 @@ func volumeAttachmentShowAction(cmd *cobra.Command, args []string) {
 	}
 	keys := KeyList{"Id", "CreatedAt", "UpdatedAt", "TenantId", "UserId", "HostInfo", "ConnectionInfo",
 		"Mountpoint", "Status", "VolumeId"}
-	PrintDict(resp, keys, fmtList)
+	PrintDict(resp, keys, attachmentFormatters)
 }
 
 func volumeAttachmentListAction(cmd *cobra.Command, args []string) {
@@ -140,7 +133,7 @@ func volumeAttachmentListAction(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 	keys := KeyList{"Id", "TenantId", "UserId", "Mountpoint", "Status", "VolumeId"}
-	PrintList(resp, keys, fmtList)
+	PrintList(resp, keys, attachmentFormatters)
 }
 
 func volumeAttachmentDeleteAction(cmd *cobra.Command, args []string) {
@@ -181,5 +174,5 @@ func volumeAttachmentUpdateAction(cmd *cobra.Command, args []string) {
 	}
 	keys := KeyList{"Id", "CreatedAt", "UpdatedAt", "TenantId", "UserId", "HostInfo", "ConnectionInfo",
 		"Mountpoint", "Status", "VolumeId"}
-	PrintDict(resp, keys, fmtList)
+	PrintDict(resp, keys, attachmentFormatters)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The attachment response items( hostInfo, connectionInfo) are too long and it's  hard read it.
This PR  add format functions that can transform  string into json format. This is also do in profile and pool.

Example print message will like below:
```
+----------------+----------------------------------------------------------------------------------------+
| Property       | Value                                                                                  |
+----------------+----------------------------------------------------------------------------------------+
| Id             | fd9f059b-1235-482c-8b19-a173604351a7                                                   |
| CreatedAt      | 2018-03-15T18:04:48                                                                    |
| UpdatedAt      | 2018-03-15T18:05:53                                                                    |
| TenantId       |                                                                                        |
| UserId         |                                                                                        |
| VolumeId       | 9fa5514d-dba0-4309-9fb0-82d8e81f23a2                                                   |
| Mountpoint     | /dev/disk/by-path/ip-127.0.0.1:3260-iscsi-iqn.2017-10.io.opensds:volume:00000001-lun-2 |
| Status         |                                                                                        |
| HostInfo       | {                                                                                      |
|                |   "platform": "amd64",                                                                 |
|                |   "osType": "linux",                                                                   |
|                |   "ip": "172.17.0.3",                                                                  |
|                |   "host": "iqn.1993-08.org.debian:01:d1f6c8e930e7",                                    |
|                |   "initiator": "iqn.1993-08.org.debian:01:d1f6c8e930e7"                                |
|                | }                                                                                      |
| ConnectionInfo | {                                                                                      |
|                |   "driverVolumeType": "iscsi",                                                         |
|                |   "data": {                                                                            |
|                |     "discard": false,                                                                  |
|                |     "targetDiscovered": true,                                                          |
|                |     "targetIQN": "iqn.2017-10.io.opensds:volume:00000001",                             |
|                |     "targetLun": 2,                                                                    |
|                |     "targetPortal": "127.0.0.1:3260"                                                   |
|                |   }                                                                                    |
|                | }                                                                                      |
+----------------+----------------------------------------------------------------------------------------+

```
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
