### PR TITLE
Decouple attach dock and provision dock

### DIFF
--- a/client/receiver.go
+++ b/client/receiver.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"strings"
 
@@ -140,26 +139,22 @@ func (k *KeystoneReciver) GetToken() error {
 
 	provider, err := openstack.AuthenticatedClient(opts)
 	if err != nil {
-		log.Printf("When get auth client:", err)
-		return err
+		return fmt.Errorf("When get auth client: %v", err)
 	}
 
 	// Only support keystone v3
 	identity, err := openstack.NewIdentityV3(provider, gophercloud.EndpointOpts{})
 	if err != nil {
-		log.Printf("When get identity session:", err)
-		return err
+		return fmt.Errorf("When get identity session: %v", err)
 	}
 	r := tokens.Create(identity, &opts)
 	token, err := r.ExtractToken()
 	if err != nil {
-		log.Printf("When get extract token session:", err)
-		return err
+		return fmt.Errorf("When get extract token session: %v", err)
 	}
 	project, err := r.ExtractProject()
 	if err != nil {
-		log.Printf("When get extract project session:", err)
-		return err
+		return fmt.Errorf("When get extract project session: %v", err)
 	}
 	k.auth.TenantID = project.ID
 	k.auth.TokenID = token.ID

--- a/cmd/osdsdock/osdsdock.go
+++ b/cmd/osdsdock/osdsdock.go
@@ -64,7 +64,7 @@ func main() {
 		}
 		break
 	default:
-		panic(fmt.Errorf("Dock type (%s) is not supportes!", CONF.OsdsDock.DockType))
+		panic(fmt.Errorf("Dock type (%s) is not supported!", CONF.OsdsDock.DockType))
 	}
 
 	// Construct dock module grpc server struct and start the listen mechanism

--- a/cmd/osdsdock/osdsdock.go
+++ b/cmd/osdsdock/osdsdock.go
@@ -20,8 +20,6 @@ This module implements a entry into the OpenSDS REST service.
 package main
 
 import (
-	"fmt"
-
 	"github.com/opensds/opensds/pkg/db"
 	"github.com/opensds/opensds/pkg/dock"
 	"github.com/opensds/opensds/pkg/dock/server"
@@ -51,20 +49,9 @@ func main() {
 	db.Init(&CONF.Database)
 
 	// Automatically discover dock and pool resources from backends.
-	dock.Brain = dock.NewDockHub()
-	switch CONF.OsdsDock.DockType {
-	case "provisioner":
-		if err := dock.Brain.TriggerDiscovery(); err != nil {
-			panic(err)
-		}
-		break
-	case "attacher":
-		if err := dock.Brain.RegisterDock(); err != nil {
-			panic(err)
-		}
-		break
-	default:
-		panic(fmt.Errorf("Dock type (%s) is not supported!", CONF.OsdsDock.DockType))
+	dock.Brain = dock.NewDockHub(CONF.OsdsDock.DockType)
+	if err := dock.Brain.TriggerDiscovery(); err != nil {
+		panic(err)
 	}
 
 	// Construct dock module grpc server struct and start the listen mechanism

--- a/examples/opensds.conf
+++ b/examples/opensds.conf
@@ -7,6 +7,8 @@ socket_order = inc
 [osdsdock]
 api_endpoint = 0.0.0.0:50050
 log_file = /var/log/opensds/osdsdock.log
+# Choose the type of dock resource, only support 'provisioner' and 'attacher'.
+dock_type = provisioner
 # Specify which backends should be enabled, sample,ceph,cinder,lvm and so on.
 enabled_backends = sample
 

--- a/pkg/dock/discovery/discovery_test.go
+++ b/pkg/dock/discovery/discovery_test.go
@@ -44,70 +44,70 @@ func init() {
 	}
 }
 
-func NewFakeDiscoverer() *DockDiscoverer {
-	return &DockDiscoverer{
+func NewFakeDockDiscoverer() *provisionDockDiscoverer {
+	return &provisionDockDiscoverer{
 		DockRegister: &DockRegister{},
 	}
 }
 
 func TestInit(t *testing.T) {
-	var dd = NewFakeDiscoverer()
+	var fdd = NewFakeDockDiscoverer()
 	var expected []*model.DockSpec
 
 	for i := range SampleDocks {
 		expected = append(expected, &SampleDocks[i])
 	}
-	if err := dd.Init(); err != nil {
+	if err := fdd.Init(); err != nil {
 		t.Errorf("Failed to init discoverer struct: %v\n", err)
 	}
-	for i := range dd.dcks {
-		dd.dcks[i].Id = ""
-		dd.dcks[i].NodeId = ""
+	for i := range fdd.dcks {
+		fdd.dcks[i].Id = ""
+		fdd.dcks[i].NodeId = ""
 		expected[i].Id = ""
 	}
-	if !reflect.DeepEqual(dd.dcks, expected) {
-		t.Errorf("Expected %+v, got %+v\n", expected, dd.dcks)
+	if !reflect.DeepEqual(fdd.dcks, expected) {
+		t.Errorf("Expected %+v, got %+v\n", expected, fdd.dcks)
 	}
 }
 
 func TestDiscover(t *testing.T) {
-	var dd = NewFakeDiscoverer()
+	var fdd = NewFakeDockDiscoverer()
 	var expected []*model.StoragePoolSpec
 
 	for i := range SampleDocks {
-		dd.dcks = append(dd.dcks, &SampleDocks[i])
+		fdd.dcks = append(fdd.dcks, &SampleDocks[i])
 	}
 	for i := range SamplePools {
 		expected = append(expected, &SamplePools[i])
 	}
-	if err := dd.Discover(); err != nil {
+	if err := fdd.Discover(); err != nil {
 		t.Errorf("Failed to discoverer pools: %v\n", err)
 	}
-	for _, pol := range dd.pols {
+	for _, pol := range fdd.pols {
 		pol.Id = ""
 	}
-	if !reflect.DeepEqual(dd.pols, expected) {
-		t.Errorf("Expected %+v, got %+v\n", expected, dd.pols)
+	if !reflect.DeepEqual(fdd.pols, expected) {
+		t.Errorf("Expected %+v, got %+v\n", expected, fdd.pols)
 	}
 }
 
-func TestStore(t *testing.T) {
-	var dd = NewFakeDiscoverer()
+func TestReport(t *testing.T) {
+	var fdd = NewFakeDockDiscoverer()
 
 	for i := range SampleDocks {
-		dd.dcks = append(dd.dcks, &SampleDocks[i])
+		fdd.dcks = append(fdd.dcks, &SampleDocks[i])
 	}
 	for i := range SamplePools {
-		dd.pols = append(dd.pols, &SamplePools[i])
+		fdd.pols = append(fdd.pols, &SamplePools[i])
 	}
 
 	mockClient := new(dbtest.MockClient)
-	mockClient.On("CreateDock", dd.dcks[0]).Return(nil, nil)
-	mockClient.On("CreatePool", dd.pols[0]).Return(nil, nil)
-	mockClient.On("CreatePool", dd.pols[1]).Return(nil, nil)
-	dd.c = mockClient
+	mockClient.On("CreateDock", fdd.dcks[0]).Return(nil, nil)
+	mockClient.On("CreatePool", fdd.pols[0]).Return(nil, nil)
+	mockClient.On("CreatePool", fdd.pols[1]).Return(nil, nil)
+	fdd.c = mockClient
 
-	if err := dd.Store(); err != nil {
+	if err := fdd.Report(); err != nil {
 		t.Errorf("Failed to store docks and pools into database: %v\n", err)
 	}
 }

--- a/pkg/dock/discovery/discovery_test.go
+++ b/pkg/dock/discovery/discovery_test.go
@@ -45,7 +45,9 @@ func init() {
 }
 
 func NewFakeDiscoverer() *DockDiscoverer {
-	return &DockDiscoverer{}
+	return &DockDiscoverer{
+		DockRegister: &DockRegister{},
+	}
 }
 
 func TestInit(t *testing.T) {
@@ -60,6 +62,7 @@ func TestInit(t *testing.T) {
 	}
 	for i := range dd.dcks {
 		dd.dcks[i].Id = ""
+		dd.dcks[i].NodeId = ""
 		expected[i].Id = ""
 	}
 	if !reflect.DeepEqual(dd.dcks, expected) {

--- a/pkg/dock/dock.go
+++ b/pkg/dock/dock.go
@@ -77,7 +77,12 @@ func (d *DockHub) TriggerDiscovery() error {
 		}
 	}(ctx)
 
-	return nil
+	return err
+}
+
+// RegisterDock
+func (d *DockHub) RegisterDock() error {
+	return discovery.RegisterAttachDock()
 }
 
 // CreateVolume

--- a/pkg/dock/dock.go
+++ b/pkg/dock/dock.go
@@ -43,16 +43,16 @@ var Brain *DockHub
 type DockHub struct {
 	// Discoverer represents the mechanism of DockHub discovering the storage
 	// capabilities from different backends.
-	Discoverer *discovery.DockDiscoverer
+	Discoverer discovery.DockDiscoverer
 	// Driver represents the specified backend resource. This field is used
 	// for initializing the specified volume driver.
 	Driver drivers.VolumeDriver
 }
 
 // NewDockHub method creates a new DockHub and returns its pointer.
-func NewDockHub() *DockHub {
+func NewDockHub(dockType string) *DockHub {
 	return &DockHub{
-		Discoverer: discovery.NewDiscoverer(),
+		Discoverer: discovery.NewDockDiscoverer(dockType),
 	}
 }
 
@@ -78,11 +78,6 @@ func (d *DockHub) TriggerDiscovery() error {
 	}(ctx)
 
 	return err
-}
-
-// RegisterDock
-func (d *DockHub) RegisterDock() error {
-	return discovery.RegisterAttachDock()
 }
 
 // CreateVolume

--- a/pkg/model/dock.go
+++ b/pkg/model/dock.go
@@ -43,6 +43,10 @@ type DockSpec struct {
 	// Endpoint represents the dock server's access address.
 	Endpoint string `json:"endpoint,omitempty"`
 
+	// NodeId represents the identification of the host, it can be considered
+	// as instance id or hostname.
+	NodeId string `json:"nodeId,omitempty"`
+
 	// DriverName represents the dock provider.
 	// Currently One of: "cinder", "ceph", "lvm", "default".
 	DriverName string `json:"driverName,omitempty"`

--- a/pkg/utils/config/config_define.go
+++ b/pkg/utils/config/config_define.go
@@ -27,6 +27,7 @@ type OsdsLet struct {
 
 type OsdsDock struct {
 	ApiEndpoint     string   `conf:"api_endpoint,localhost:50050"`
+	DockType        string   `conf:"dock_type,provisioner"`
 	EnabledBackends []string `conf:"enabled_backends,lvm"`
 	Daemon          bool     `conf:"daemon,false"`
 	Backends


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Normally Provision Dock will trigger capability report but Attach Dock will not, so we need to decouple these two services to avoid some errors.

**Which issue this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
