### PR TITLE
Update mailing list and meeting info

### DIFF
--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -4,16 +4,19 @@ Covers discussion of OpenSDS Controller architecture design and featrue developm
 
 ## Meetings
 
-- The meeting will be held on biweekly Tuesday at 1:00 UTC. Join in at [here](https://zoom.us/j/933703258).
-- Meeting notes and agenda can be found at [here](https://docs.google.com/document/d/1OKDp7iDw_l_5kGyniqTKtrwRFAZMvItGghsxfrCqr5c/edit#).
+- The meeting are held [every other Tuesday](https://zoom.us/j/777978108) at
+  12:00 Easter Time US and [every other Thursday](https://zoom.us/j/297629570)
+  at 20:00 Eastern Time US.
+- Meeting notes and agenda can be found [here](https://docs.google.com/document/d/1JlxAAOtvZvvf_KhVr8XQa6mUD7lkHOXlxuGruTKEukE/edit#).
 
 If you are interested at work trackings on the meeting, please visit [WG Planning](https://docs.google.com/spreadsheets/d/1eFZsYCqTW8-zc8K6IMFUVhmzrZQKpOeO8Br0cCraPlU/edit#gid=1359957213).
 
 ## Leaders
 
+- [Xing Yang](https://github.com/xing-yang), Huawei
 - [Leon Wang](https://github.com/leonwanghui), Huawei
 
 ## Contact
 
 - [Slack](https://opensds.slack.com)
-- [Google Group](https://groups.google.com/forum/?hl=en#!forum/opensds-dev)
+- [Mailing List](https://lists.opensds.io/mailman/listinfo/opensds-tech-discuss)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ opensds is Apache 2.0 licensed and accepts contributions via GitHub pull request
 
 ## Email and chat
 
-- Email: [opensds-dev](https://groups.google.com/forum/?hl=en#!forum/opensds-dev)
+- Email: [opensds-dev](https://lists.opensds.io/mailman/listinfo)
 - Slack: #[opensds](https://opensds.slack.com) 
 
 Before you start, NOTICE that ```master``` branch is the relatively stable version

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ unified block, file, object storage services and focuses on:
 The OpenSDS community welcomes anyone who is interested in software defined
 storage and shaping the future of cloud-era storage. If you are a company,
 you should consider joining the [OpenSDS Project](https://opensds.io/). 
-If you are a developer want to be part of the code development that is happening
-now, please refer to the Contributing sections below.
+If you are a developer and would like to be part of the code development
+that is happening now, please refer to the Contributing sections below.
 
 ## Collaborative Testing
 
@@ -43,7 +43,7 @@ now, please refer to the Contributing sections below.
 
 ## Contact
 
-* Mailing list: [opensds-dev](https://groups.google.com/forum/?hl=en#!forum/opensds-dev)
+* Mailing list: [opensds-tech-discuss](https://lists.opensds.io/mailman/listinfo/opensds-tech-discuss)
 * slack: #[opensds](https://opensds.slack.com)
 * Ideas/Bugs: [issues](https://github.com/opensds/opensds/issues)
 
@@ -51,26 +51,21 @@ now, please refer to the Contributing sections below.
 
 See [COMMUNITY](COMMUNITY.md) for details on discussion of the OpenSDS architecture design and feature development.
 
-* The meeting will be held on Biweekly Tuesday at 1:00 UTC. Join in at [here](https://zoom.us/j/933703258).
-* Meeting notes and agenda can be found at [here](https://docs.google.com/document/d/1OKDp7iDw_l_5kGyniqTKtrwRFAZMvItGghsxfrCqr5c/edit#).
-
-If you are interested at work trackings on the meeting, please visit [WG Planning](https://docs.google.com/spreadsheets/d/1eFZsYCqTW8-zc8K6IMFUVhmzrZQKpOeO8Br0cCraPlU/edit#gid=0).
-
 ## Contributing
 
-If you're interested in being a contributor and want to get involved in the
-opensds code developing, please see [CONTRIBUTING](CONTRIBUTING.md) for 
+If you're interested in being a contributor and want to get involved in
+developing the OpenSDS code, please see [CONTRIBUTING](CONTRIBUTING.md) for
 details on submitting patches and the contribution workflow.
 
 ## Hacking
 
 Please refer to [HACKING](HACKING.md) for any requirements when you want to perform code
-development for opensds.
+development for OpenSDS.
 
 ## Installation
 
 Please refer to [INSTALL](INSTALL.md) for any requirements when you want to perform code
-development for opensds.
+development for OpenSDS.
 
 ## License
 


### PR DESCRIPTION
Switching over from the Google Group now that we have our own
listserv mailing lists. Also updating some of the meeting
references to reflect the latest schedule.
