### PR TITLE
Remove -f option from lvm volume deletion.

### DIFF
--- a/contrib/drivers/lvm/lvm.go
+++ b/contrib/drivers/lvm/lvm.go
@@ -140,7 +140,7 @@ func (d *Driver) DeleteVolume(opt *pb.DeleteVolumeOpts) error {
 		return err
 	}
 	if _, err := d.handler("lvremove", []string{
-		"-f", lvPath,
+		lvPath,
 	}); err != nil {
 		log.Error("Failed to remove logic volume:", err)
 		return err


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:  
Remove -f option from lvm volume deletion.  

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #356 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
