### PR TITLE
Refatored the LVM ISCSI feature.

### DIFF
--- a/contrib/drivers/lvm/lvm.go
+++ b/contrib/drivers/lvm/lvm.go
@@ -183,10 +183,16 @@ func (d *Driver) ExtendVolume(opt *pb.ExtendVolumeOpts) (*model.VolumeSpec, erro
 }
 
 func (d *Driver) InitializeConnection(opt *pb.CreateAttachmentOpts) (*model.ConnectionInfo, error) {
-	var initiator string
-	if initiator = opt.HostInfo.GetInitiator(); initiator == "" {
+	initiator := opt.HostInfo.GetInitiator()
+	if initiator == "" {
 		initiator = "ALL"
 	}
+
+	hostIP := opt.HostInfo.GetIp()
+	if hostIP == "" {
+		initiator = "ALL"
+	}
+
 	lvPath, ok := opt.GetMetadata()["lvPath"]
 	if !ok {
 		err := errors.New("Failed to find logic volume path in volume attachment metadata!")
@@ -195,7 +201,7 @@ func (d *Driver) InitializeConnection(opt *pb.CreateAttachmentOpts) (*model.Conn
 	}
 
 	t := targets.NewTarget(d.conf.TgtBindIp, d.conf.TgtConfDir)
-	expt, err := t.CreateExport(opt.GetVolumeId(), lvPath, initiator)
+	expt, err := t.CreateExport(opt.GetVolumeId(), lvPath, hostIP, initiator)
 	if err != nil {
 		log.Error("Failed to initialize connection of logic volume:", err)
 		return nil, err

--- a/contrib/drivers/lvm/lvm_test.go
+++ b/contrib/drivers/lvm/lvm_test.go
@@ -52,8 +52,9 @@ func TestSetup(t *testing.T) {
 	config.CONF.OsdsDock.Backends.LVM.ConfigPath = "testdata/lvm.yaml"
 	var expectedDriver = &Driver{
 		conf: &LVMConfig{
-			Pool:      fp,
-			TgtBindIp: "192.168.56.105",
+			Pool:       fp,
+			TgtBindIp:  "192.168.56.105",
+			TgtConfDir: "/etc/tgt/conf.d",
 		},
 		handler: execCmd,
 	}

--- a/contrib/drivers/lvm/targets/iscsi.go
+++ b/contrib/drivers/lvm/targets/iscsi.go
@@ -31,7 +31,7 @@ const (
 )
 
 type ISCSITarget interface {
-	CreateISCSITarget(volId, tgtIqn, path, initiator string, chapAuth []string) error
+	CreateISCSITarget(volId, tgtIqn, path, hostIp, initiator string, chapAuth []string) error
 	GetISCSITarget(iqn string) int
 	RemoveISCSITarget(volId, iqn string) error
 	GetLun(path string) int
@@ -81,7 +81,7 @@ func (t *tgtTarget) getTgtConfPath(volId string) string {
 	return t.TgtConfDir + "/" + opensdsPrefix + volId + ".conf"
 }
 
-func (t *tgtTarget) CreateISCSITarget(volId, tgtIqn, path, initiator string, chapAuth []string) error {
+func (t *tgtTarget) CreateISCSITarget(volId, tgtIqn, path, hostIp, initiator string, chapAuth []string) error {
 
 	if exist, _ := utils.PathExists(t.TgtConfDir); !exist {
 		os.MkdirAll(t.TgtConfDir, 0755)
@@ -102,10 +102,9 @@ func (t *tgtTarget) CreateISCSITarget(volId, tgtIqn, path, initiator string, cha
 	write-cache %s
 </target>
 `
-	var initiatorAddr string
+	var initiatorAddr = "initiator-address" + hostIp
 	var initiatorName string
 	if initiator != "ALL" {
-		initiatorAddr = "initiator-address ALL"
 		initiatorName = "initiator-name " + initiator
 	}
 
@@ -175,7 +174,7 @@ func (t *tgtTarget) RemoveISCSITarget(volId, iqn string) error {
 
 func (*tgtTarget) execCmd(name string, cmd ...string) (string, error) {
 	ret, err := exec.Command(name, cmd...).Output()
-	log.V(8).Infoln("Command: ", "tgtadm ", strings.Join(cmd, " "))
+	log.V(8).Infoln("Command:", cmd, strings.Join(cmd, " "))
 	log.V(8).Infof("result:%s", string(ret))
 	if err != nil {
 		log.V(8).Info("error info:", err)

--- a/contrib/drivers/lvm/targets/iscsi.go
+++ b/contrib/drivers/lvm/targets/iscsi.go
@@ -21,48 +21,48 @@ import (
 	"strings"
 
 	log "github.com/golang/glog"
+	"github.com/opensds/opensds/pkg/utils"
+	"os"
 )
 
 type ISCSITarget interface {
-	CreateISCSITarget() error
-	GetISCSITarget() int
-	RemoveISCSITarget() error
+	CreateISCSITarget(volId, tgtIqn, path, initiator string, chapAuth []string) error
+	GetISCSITarget(iqn string) int
+	RemoveISCSITarget(volId, iqn string) error
 
-	AddLun(lun int, path string) error
+	AddLun(tid, lun int, path string) error
 	GetLun(path string) int
-	RemoveLun(lun int) error
+	RemoveLun(tid, lun int) error
 
-	BindInitiatorName(initiator string) error
-	UnbindInitiatorName(initiator string) error
+	BindInitiatorName(tid, initiator string) error
+	UnbindInitiatorName(tid, initiator string) error
 
-	BindInitiatorAddress(initiator string) error
-	UnbindInitiatorAddress(initiator string) error
+	BindInitiatorAddress(tid, initiator string) error
+	UnbindInitiatorAddress(tid, initiator string) error
 }
 
-func NewISCSITarget(tid int, name string, bip string) ISCSITarget {
+func NewISCSITarget(bip, tgtConfDir string) ISCSITarget {
 	return &tgtTarget{
-		Tid:    tid,
-		TName:  name,
-		BindIp: bip,
+		TgtConfDir: tgtConfDir,
+		BindIp:     bip,
 	}
 }
 
 type tgtTarget struct {
-	Tid    int
-	TName  string
-	BindIp string
+	BindIp     string
+	TgtConfDir string
 }
 
-func (t *tgtTarget) AddLun(lun int, path string) error {
+func (t *tgtTarget) AddLun(tid, lun int, path string) error {
 	var cmd = []string{
 		"--lld", "iscsi",
 		"--op", "new",
 		"--mode", "logicalunit",
-		"--tid", fmt.Sprint(t.Tid),
+		"--tid", fmt.Sprint(tid),
 		"--lun", fmt.Sprint(lun),
 		"--backing-store", path,
 	}
-	if _, err := t.execCmd(cmd); err != nil {
+	if _, err := t.execCmd("tgtadm", cmd...); err != nil {
 		log.Error("Fail to exec 'tgtadm' to add lun into iscsi target:", err)
 		return err
 	}
@@ -76,7 +76,7 @@ func (t *tgtTarget) GetLun(path string) int {
 		"--op", "show",
 		"--mode", "target",
 	}
-	out, err := t.execCmd(cmd)
+	out, err := t.execCmd("tgtadm", cmd...)
 	if err != nil {
 		log.Error("Fail to exec 'tgtadm' to display iscsi target:", err)
 		return -1
@@ -103,15 +103,15 @@ func (t *tgtTarget) GetLun(path string) int {
 	return -1
 }
 
-func (t *tgtTarget) RemoveLun(lun int) error {
+func (t *tgtTarget) RemoveLun(tid, lun int) error {
 	var cmd = []string{
 		"--lld", "iscsi",
 		"--op", "delete",
 		"--mode", "logicalunit",
-		"--tid", fmt.Sprint(t.Tid),
+		"--tid", fmt.Sprint(tid),
 		"--lun", fmt.Sprint(lun),
 	}
-	if _, err := t.execCmd(cmd); err != nil {
+	if _, err := t.execCmd("tgtadm", cmd...); err != nil {
 		log.Error("Fail to exec 'tgtadm' to remove lun from iscsi target:", err)
 		return err
 	}
@@ -119,29 +119,69 @@ func (t *tgtTarget) RemoveLun(lun int) error {
 	return nil
 }
 
-func (t *tgtTarget) CreateISCSITarget() error {
-	var cmd = []string{
-		"--lld", "iscsi",
-		"--op", "new",
-		"--mode", "target",
-		"--tid", fmt.Sprint(t.Tid),
-		"-T", t.TName,
+func (t *tgtTarget) CreateISCSITarget(volId, tgtIqn, path, initiator string, chapAuth []string) error {
+
+	if exist, _ := utils.PathExists(t.TgtConfDir); !exist {
+		os.MkdirAll(t.TgtConfDir, 0755)
 	}
-	if _, err := t.execCmd(cmd); err != nil {
-		log.Error("Fail to exec 'tgtadm' to create iscsi target:", err)
+
+	var charStr string
+	if len(chapAuth) != 0 {
+		charStr = fmt.Sprintf("incominguser %s %s", chapAuth[0], chapAuth[1])
+	}
+
+	tgtConfPath := t.TgtConfDir + "/" + volId + ".conf"
+
+	var tgtConfFormatter = `
+<target %s>
+	backing-store %s
+	driver %s
+	%s
+	%s
+	%s
+	write-cache %s
+</target>
+`
+	var initiatorAddr string
+	var initiatorName string
+	if initiator != "ALL" {
+		initiatorAddr = "initiator-address ALL"
+		initiatorName = "initiator-name " + initiator
+	}
+
+	confStr := fmt.Sprintf(tgtConfFormatter, tgtIqn, path, "iscsi", charStr, initiatorAddr, initiatorName, "on")
+	f, err := os.Create(tgtConfPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	f.WriteString(confStr)
+	f.Sync()
+
+	if info, err := t.execCmd("tgt-admin", "--update", tgtIqn); err != nil {
+		log.Error("Fail to exec 'tgtadm' to create iscsi target, ", info, err)
 		return err
 	}
 
+	if t.GetISCSITarget(tgtIqn) == -1 {
+		log.Errorf("Failed to create iscsi target for Volume "+
+			"ID: %s. It could be caused by problem "+
+			"with concurrency. "+
+			"Also please ensure your tgtd config "+
+			"file contains 'include %s/*'",
+			volId, t.TgtConfDir)
+		return fmt.Errorf("failed to create volume(%s) attachment", volId)
+	}
 	return nil
 }
 
-func (t *tgtTarget) GetISCSITarget() int {
+func (t *tgtTarget) GetISCSITarget(iqn string) int {
 	var cmd = []string{
 		"--lld", "iscsi",
 		"--op", "show",
 		"--mode", "target",
 	}
-	out, err := t.execCmd(cmd)
+	out, err := t.execCmd("tgtadm", cmd...)
 	if err != nil {
 		log.Error("Fail to exec 'tgtadm' to display iscsi target:", err)
 		return -1
@@ -149,7 +189,7 @@ func (t *tgtTarget) GetISCSITarget() int {
 
 	var tid = -1
 	for _, line := range strings.Split(out, "\n") {
-		if strings.Contains(line, t.TName) {
+		if strings.Contains(line, iqn) {
 			tidString := strings.Fields(strings.Split(line, ":")[0])[1]
 			tid, err = strconv.Atoi(tidString)
 			if err != nil {
@@ -161,91 +201,132 @@ func (t *tgtTarget) GetISCSITarget() int {
 	return tid
 }
 
-func (t *tgtTarget) RemoveISCSITarget() error {
-	var cmd = []string{
-		"--lld", "iscsi",
-		"--op", "delete",
-		"--force",
-		"--mode", "target",
-		"--tid", fmt.Sprint(t.Tid),
+func (t *tgtTarget) RemoveISCSITarget(volId, iqn string) error {
+	tgtConfPath := t.TgtConfDir + "/" + volId + ".conf"
+	if exist, _ := utils.PathExists(tgtConfPath); !exist {
+		log.Warningf("Volume path %s does not exist, nothing to remove.", tgtConfPath)
+		return nil
 	}
-	if _, err := t.execCmd(cmd); err != nil {
-		log.Error("Fail to exec 'tgtadm' to forcely remove iscsi target:", err)
+
+	if info, err := t.execCmd("tgt-admin", "--force", "--delete", iqn); err != nil {
+		log.Error("Fail to exec 'tgtadm' to forcely remove iscsi target", info, err)
 		return err
 	}
 
+	os.Remove(tgtConfPath)
 	return nil
 }
-
-func (t *tgtTarget) BindInitiatorName(initiator string) error {
+func (t *tgtTarget) isBindInitiatorName(tid, initiator string) bool {
 	var cmd = []string{
 		"--lld", "iscsi",
-		"--op", "bind",
+		"--op", "show",
 		"--mode", "target",
-		"--tid", fmt.Sprint(t.Tid),
-		"--initiator-name", initiator,
 	}
-	if _, err := t.execCmd(cmd); err != nil {
-		log.Error("Fail to exec 'tgtadm' to bind iscsi target:", err)
-		return err
-	}
-
-	return nil
-}
-
-func (t *tgtTarget) UnbindInitiatorName(initiator string) error {
-	var cmd = []string{
-		"--lld", "iscsi",
-		"--op", "unbind",
-		"--mode", "target",
-		"--tid", fmt.Sprint(t.Tid),
-		"--initiator-name", initiator,
-	}
-	if _, err := t.execCmd(cmd); err != nil {
-		log.Error("Fail to exec 'tgtadm' to unbind iscsi target:", err)
-		return err
-	}
-
-	return nil
-}
-
-func (t *tgtTarget) BindInitiatorAddress(initiator string) error {
-	var cmd = []string{
-		"--lld", "iscsi",
-		"--op", "bind",
-		"--mode", "target",
-		"--tid", fmt.Sprint(t.Tid),
-		"--initiator-address", initiator,
-	}
-	if _, err := t.execCmd(cmd); err != nil {
-		log.Error("Fail to exec 'tgtadm' to bind iscsi target:", err)
-		return err
-	}
-
-	return nil
-}
-
-func (t *tgtTarget) UnbindInitiatorAddress(initiator string) error {
-	var cmd = []string{
-		"--lld", "iscsi",
-		"--op", "unbind",
-		"--mode", "target",
-		"--tid", fmt.Sprint(t.Tid),
-		"--initiator-address", initiator,
-	}
-	if _, err := t.execCmd(cmd); err != nil {
-		log.Error("Fail to exec 'tgtadm' to unbind iscsi target:", err)
-		return err
-	}
-
-	return nil
-}
-
-func (*tgtTarget) execCmd(cmd []string) (string, error) {
-	ret, err := exec.Command("tgtadm", cmd...).Output()
+	out, err := t.execCmd("tgtadm", cmd...)
 	if err != nil {
-		log.Error(err.Error())
-		return "", err
+		log.Error("Fail to exec 'tgtadm' to display iscsi target:", err)
+		return false
 	}
-	return string(ret), nil
+
+	indent := 0
+	tgtPrefix := fmt.Sprintf("Target %d", tid)
+	var lines = strings.Split(out, "\n")
+	for _, line := range lines {
+		if strings.HasPrefix(line, tgtPrefix) {
+			indent++
+			continue
+		}
+		if indent == 1 && strings.HasPrefix(line, "    ACL information:") {
+			indent++
+			continue
+		}
+		if indent == 2 {
+			// ACL bind ip indent 8 spaces
+			if !strings.HasPrefix(line, "        ") {
+				return false
+			}
+			if strings.Contains(line, initiator) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (t *tgtTarget) BindInitiatorName(tid, initiator string) error {
+	if t.isBindInitiatorName(tid, initiator) {
+		log.Infof("Specified initiator %s has already been bound to target %d", initiator, tid)
+		return nil
+	}
+	var cmd = []string{
+		"--lld", "iscsi",
+		"--op", "bind",
+		"--mode", "target",
+		"--tid", fmt.Sprint(tid),
+		"--initiator-name", initiator,
+	}
+	if _, err := t.execCmd("tgtadm", cmd...); err != nil {
+		log.Error("Fail to exec 'tgtadm' to bind iscsi target:", err)
+		return err
+	}
+
+	return nil
+}
+
+func (t *tgtTarget) UnbindInitiatorName(tid, initiator string) error {
+	var cmd = []string{
+		"--lld", "iscsi",
+		"--op", "unbind",
+		"--mode", "target",
+		"--tid", fmt.Sprint(tid),
+		"--initiator-name", initiator,
+	}
+	if _, err := t.execCmd("tgtadm", cmd...); err != nil {
+		log.Error("Fail to exec 'tgtadm' to unbind iscsi target:", err)
+		return err
+	}
+
+	return nil
+}
+
+func (t *tgtTarget) BindInitiatorAddress(tid, initiator string) error {
+	var cmd = []string{
+		"--lld", "iscsi",
+		"--op", "bind",
+		"--mode", "target",
+		"--tid", fmt.Sprint(tid),
+		"--initiator-address", initiator,
+	}
+	if _, err := t.execCmd("tgtadm", cmd...); err != nil {
+		log.Error("Fail to exec 'tgtadm' to bind iscsi target:", err)
+		return err
+	}
+
+	return nil
+}
+
+func (t *tgtTarget) UnbindInitiatorAddress(tid, initiator string) error {
+	var cmd = []string{
+		"--lld", "iscsi",
+		"--op", "unbind",
+		"--mode", "target",
+		"--tid", fmt.Sprint(tid),
+		"--initiator-address", initiator,
+	}
+	if _, err := t.execCmd("tgtadm", cmd...); err != nil {
+		log.Error("Fail to exec 'tgtadm' to unbind iscsi target:", err)
+		return err
+	}
+
+	return nil
+}
+
+func (*tgtTarget) execCmd(name string, cmd ...string) (string, error) {
+	ret, err := exec.Command(name, cmd...).Output()
+	log.V(8).Infoln("Command: ", "tgtadm ", strings.Join(cmd, " "))
+	log.V(8).Infof("result:%s", string(ret))
+	if err != nil {
+		log.V(8).Info("error info:", err)
+	}
+	return string(ret), err
 }

--- a/contrib/drivers/lvm/targets/targets.go
+++ b/contrib/drivers/lvm/targets/targets.go
@@ -21,7 +21,7 @@ const (
 // Target is an interface for exposing some operations of different targets,
 // currently support iscsiTarget.
 type Target interface {
-	CreateExport(volId, path, initiator string) (map[string]interface{}, error)
+	CreateExport(volId, path, hostIp, initiator string) (map[string]interface{}, error)
 
 	RemoveExport(volId string) error
 }
@@ -37,9 +37,9 @@ type iscsiTarget struct {
 	ISCSITarget
 }
 
-func (t *iscsiTarget) CreateExport(volId, path, initiator string) (map[string]interface{}, error) {
+func (t *iscsiTarget) CreateExport(volId, path, hostIp, initiator string) (map[string]interface{}, error) {
 	tgtIqn := iscsiTgtPrefix + volId
-	if err := t.CreateISCSITarget(volId, tgtIqn, path, initiator, []string{}); err != nil {
+	if err := t.CreateISCSITarget(volId, tgtIqn, path, hostIp, initiator, []string{}); err != nil {
 		return nil, err
 	}
 	lunId := t.GetLun(path)

--- a/contrib/drivers/lvm/targets/targets.go
+++ b/contrib/drivers/lvm/targets/targets.go
@@ -14,32 +14,22 @@
 
 package targets
 
-import (
-	"errors"
-)
-
 const (
-	globalTid = 1
-	globalIQN = "iqn.2017-10.io.opensds:volume:00000001"
-	baseNum   = 100
-)
-
-var (
-	globalLun = 1
+	iscsiTgtPrefix = "iqn.2017-10.io.opensds:"
 )
 
 // Target is an interface for exposing some operations of different targets,
 // currently support iscsiTarget.
 type Target interface {
-	CreateExport(path, initiator string) (map[string]interface{}, error)
+	CreateExport(volId, path, initiator string) (map[string]interface{}, error)
 
-	RemoveExport(path, initiator string) error
+	RemoveExport(volId string) error
 }
 
 // NewTarget method creates a new iscsi target.
-func NewTarget(bip string) Target {
+func NewTarget(bip string, tgtConfDir string) Target {
 	return &iscsiTarget{
-		ISCSITarget: NewISCSITarget(globalTid, globalIQN, bip),
+		ISCSITarget: NewISCSITarget(bip, tgtConfDir),
 	}
 }
 
@@ -47,44 +37,22 @@ type iscsiTarget struct {
 	ISCSITarget
 }
 
-func (t *iscsiTarget) CreateExport(path, initiator string) (map[string]interface{}, error) {
-	globalLun = (globalLun + 1) % baseNum
-
-	if t.GetISCSITarget() != globalTid {
-		if err := t.CreateISCSITarget(); err != nil {
-			return nil, err
-		}
-		if err := t.BindInitiatorAddress("ALL"); err != nil {
-			return nil, err
-		}
-	}
-	if err := t.AddLun(globalLun, path); err != nil {
+func (t *iscsiTarget) CreateExport(volId, path, initiator string) (map[string]interface{}, error) {
+	tgtIqn := iscsiTgtPrefix + volId
+	if err := t.CreateISCSITarget(volId, tgtIqn, path, initiator, []string{}); err != nil {
 		return nil, err
 	}
-	if err := t.BindInitiatorName(initiator); err != nil {
-		return nil, err
-	}
-
+	lunId := t.GetLun(path)
 	return map[string]interface{}{
 		"targetDiscovered": true,
-		"targetIQN":        globalIQN,
+		"targetIQN":        tgtIqn,
 		"targetPortal":     t.ISCSITarget.(*tgtTarget).BindIp + ":3260",
 		"discard":          false,
-		"targetLun":        globalLun,
+		"targetLun":        lunId,
 	}, nil
 }
 
-func (t *iscsiTarget) RemoveExport(path, initiator string) error {
-	if err := t.UnbindInitiatorName(initiator); err != nil {
-		return err
-	}
-	lun := t.GetLun(path)
-	if lun == -1 {
-		return errors.New("Can't find lun with path " + path)
-	}
-	if err := t.RemoveLun(lun); err != nil {
-		return err
-	}
-
-	return t.RemoveISCSITarget()
+func (t *iscsiTarget) RemoveExport(volId string) error {
+	tgtIqn := iscsiTgtPrefix + volId
+	return t.RemoveISCSITarget(volId, tgtIqn)
 }

--- a/contrib/drivers/lvm/testdata/lvm.yaml
+++ b/contrib/drivers/lvm/testdata/lvm.yaml
@@ -1,4 +1,5 @@
 tgtBindIp: 192.168.56.105
+tgtConfDir: /etc/tgt/conf.d
 pool:
   vg001:
     storageType: block


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Using persistent configure file instead of command `tgtadm`  to initialize the iscsi  connection.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
