### PR TITLE
Add keystone install feature in devsds

### DIFF
--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -20,9 +20,9 @@ This module implements a entry into the OpenSDS northbound REST service.
 package api
 
 import (
+	"fmt"
 	"net/http"
 
-	"fmt"
 	"github.com/astaxie/beego"
 	bctx "github.com/astaxie/beego/context"
 	"github.com/opensds/opensds/pkg/api/filter/auth"

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -22,10 +22,12 @@ package api
 import (
 	"net/http"
 
+	"fmt"
 	"github.com/astaxie/beego"
 	bctx "github.com/astaxie/beego/context"
 	"github.com/opensds/opensds/pkg/api/filter/auth"
 	"github.com/opensds/opensds/pkg/api/filter/context"
+	"github.com/opensds/opensds/pkg/utils/constants"
 )
 
 const (
@@ -37,7 +39,7 @@ func Run(host string) {
 
 	// add router for v1beta api
 	ns :=
-		beego.NewNamespace("/v1beta",
+		beego.NewNamespace("/"+constants.ApiVersion,
 			beego.NSCond(func(ctx *bctx.Context) bool {
 				// To judge whether the scheme is legal or not.
 				if ctx.Input.Scheme() != "http" && ctx.Input.Scheme() != "https" {
@@ -82,10 +84,12 @@ func Run(host string) {
 				// Creates, shows, lists, unpdates and deletes snapshot.
 				beego.NSRouter("/snapshots", &VolumeSnapshotPortal{}, "post:CreateVolumeSnapshot;get:ListVolumeSnapshots"),
 				beego.NSRouter("/snapshots/:snapshotId", &VolumeSnapshotPortal{}, "get:GetVolumeSnapshot;put:UpdateVolumeSnapshot;delete:DeleteVolumeSnapshot"),
+
 				// Creates, shows, lists, unpdates and deletes replication.
 				beego.NSRouter("/replications", NewReplicationPortal(), "post:CreateReplication;get:ListReplications"),
 				beego.NSRouter("/replications/detail", NewReplicationPortal(), "get:ListReplicationsDetail"),
 				beego.NSRouter("/replications/:replicationId", NewReplicationPortal(), "get:GetReplication;put:UpdateReplication;delete:DeleteReplication"),
+				beego.NSRouter("/replications/:replicationId/action", NewReplicationPortal(), "put:Action"),
 				beego.NSRouter("/replications/:replicationId/action", NewReplicationPortal(), "post:Action"),
 				// Volume group contains a list of volumes that are used in the same application.
 				beego.NSRouter("/volumeGroup", &VolumeGroupPortal{}, "post:CreateVolumeGroup"),
@@ -94,10 +98,9 @@ func Run(host string) {
 			// Extend Volume
 			beego.NSRouter("/:tenantId/volumes/:volumeId/action", &VolumePortal{}, "post:ExtendVolume"),
 		)
-	beego.InsertFilter("*", beego.BeforeExec, context.Factory())
-	beego.InsertFilter("*", beego.BeforeExec, auth.Factory())
-	//ns.Filter("before", context.Factory())
-	//ns.Filter("before", auth.Factory())
+	pattern := fmt.Sprintf("/%s/*", constants.ApiVersion)
+	beego.InsertFilter(pattern, beego.BeforeExec, context.Factory())
+	beego.InsertFilter(pattern, beego.BeforeExec, auth.Factory())
 	beego.AddNamespace(ns)
 
 	// add router for api version

--- a/pkg/utils/constants/constants.go
+++ b/pkg/utils/constants/constants.go
@@ -26,4 +26,6 @@ const (
 	// Token parameter name
 	AuthTokenHeader    = "X-Auth-Token"
 	SubjectTokenHeader = "X-Subject-Token"
+
+	ApiVersion = "v1beta"
 )

--- a/script/CI/test
+++ b/script/CI/test
@@ -42,7 +42,7 @@ sudo rm /etc/opensds/opensds.conf -rf
 
 # Start lvm e2e test
 split_line "Start lvm e2e test"
-sudo $OPENSDS_DIR/script/devsds/install.sh -b lvm
+sudo $OPENSDS_DIR/script/devsds/install.sh
 ps -ef|grep osds
 go test -v github.com/opensds/opensds/test/e2e/... -tags e2e
 sudo $OPENSDS_DIR/script/devsds/uninstall.sh

--- a/script/devsds/lib/keystone.sh
+++ b/script/devsds/lib/keystone.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2018 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# 'stack' user is just for install keystone through devstack
+
+_XTRACE_KEYSTONE=$(set +o | grep xtrace)
+set +o xtrace
+
+osds::keystone::create_user(){
+    if id ${STACK_USER_NAME} &> /dev/null; then
+        return
+    fi
+    sudo useradd -s /bin/bash -d ${STACK_HOME} -m ${STACK_USER_NAME}
+    echo "stack ALL=(ALL) NOPASSWD: ALL" | sudo tee /etc/sudoers.d/stack
+}
+
+
+osds::keystone::remove_user(){
+    userdel ${STACK_USER_NAME} -f -r
+    rm /etc/sudoers.d/stack
+}
+
+osds::keystone::devstack_local_conf(){
+DEV_STACK_LOCAL_CONF=${DEV_STACK_DIR}/local.conf
+cat > $DEV_STACK_LOCAL_CONF << DEV_STACK_LOCAL_CONF_DOCK
+[[local|localrc]]
+# use TryStack git mirror
+GIT_BASE=$STACK_GIT_BASE
+
+# If the ``*_PASSWORD`` variables are not set here you will be prompted to enter
+# values for them by ``stack.sh``and they will be added to ``local.conf``.
+ADMIN_PASSWORD=$STACK_PASSWORD
+DATABASE_PASSWORD=$STACK_PASSWORD
+RABBIT_PASSWORD=$STACK_PASSWORD
+SERVICE_PASSWORD=$STACK_PASSWORD
+
+# Neither is set by default.
+HOST_IP=$HOST_IP
+
+# path of the destination log file.  A timestamp will be appended to the given name.
+LOGFILE=\$DEST/logs/stack.sh.log
+
+# Old log files are automatically removed after 7 days to keep things neat.  Change
+# the number of days by setting ``LOGDAYS``.
+LOGDAYS=2
+
+ENABLED_SERVICES=mysql,key
+# Using stable/queens branches
+# ---------------------------------
+KEYSTONE_BRANCH=$STACK_BRANCH
+KEYSTONECLIENT_BRANCH=$STACK_BRANCH
+DEV_STACK_LOCAL_CONF_DOCK
+chown stack:stack $DEV_STACK_LOCAL_CONF
+}
+
+osds::keystone::opensds_conf() {
+cat >> $OPENSDS_CONFIG_DIR/opensds.conf << OPENSDS_GLOBAL_CONFIG_DOC
+[keystone_authtoken]
+memcached_servers = $HOST_IP:11211
+signing_dir = /var/cache/opensds
+cafile = /opt/stack/data/ca-bundle.pem
+auth_uri = http://$HOST_IP/identity
+project_domain_name = Default
+project_name = service
+user_domain_name = Default
+password = $STACK_PASSWORD
+username = $OPENSDS_SERVER_NAME
+auth_url = http://$HOST_IP/identity
+auth_type = password
+
+OPENSDS_GLOBAL_CONFIG_DOC
+
+cp $OPENSDS_DIR/examples/policy.json $OPENSDS_CONFIG_DIR
+}
+
+osds::keystone::create_user_and_endpoint(){
+    . $DEV_STACK_DIR/openrc admin admin
+    openstack user create --domain default --password $STACK_PASSWORD $OPENSDS_SERVER_NAME
+    openstack role add --project service --user opensds admin
+    openstack service create --name opensds$OPENSDS_VERSION --description "OpenSDS Block Storage" opensds$OPENSDS_VERSION
+    openstack endpoint create --region RegionOne opensds$OPENSDS_VERSION public http://$HOST_IP:50040/$OPENSDS_VERSION/%\(tenant_id\)s
+    openstack endpoint create --region RegionOne opensds$OPENSDS_VERSION internal http://$HOST_IP:50040/$OPENSDS_VERSION/%\(tenant_id\)s
+    openstack endpoint create --region RegionOne opensds$OPENSDS_VERSION admin http://$HOST_IP:50040/$OPENSDS_VERSION/%\(tenant_id\)s
+}
+
+
+osds::keystone::download_code(){
+    if [ ! -d ${DEV_STACK_DIR} ];then
+        git clone ${STACK_GIT_BASE}/openstack-dev/devstack.git -b ${STACK_BRANCH} ${DEV_STACK_DIR}
+        chown stack:stack -R ${DEV_STACK_DIR}
+    fi
+
+}
+
+osds::keystone::install(){
+    osds::keystone::create_user
+    osds::keystone::download_code
+    osds::keystone::opensds_conf
+
+    # If keystone is on there no need continue next steps.
+    if osds::util::wait_for_url http://$HOST_IP/identity "keystone" 0.25 4; then
+        return
+    fi
+    osds::keystone::devstack_local_conf
+    cd ${DEV_STACK_DIR}
+    su $STACK_USER_NAME -c ${DEV_STACK_DIR}/stack.sh
+    osds::keystone::create_user_and_endpoint
+}
+
+osds::keystone::cleanup() {
+    : #do nothing
+}
+
+osds::keystone::uninstall(){
+    su $STACK_USER_NAME -c ${DEV_STACK_DIR}/unstack.sh
+}
+
+osds::keystone::uninstall_purge(){
+    rm $STACK_HOME/* -rf
+    osds::keystone::remove_user
+}
+
+## Restore xtrace
+$_XTRACE_KEYSTONE

--- a/script/devsds/lib/opensds.sh
+++ b/script/devsds/lib/opensds.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+# Copyright (c) 2018 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# OpenSDS relative operation.
+
+_XTRACE_OPENSDS=$(set +o | grep xtrace)
+set +o xtrace
+
+
+osds:opensds:configuration(){
+# Set global configuration.
+cat >> $OPENSDS_CONFIG_DIR/opensds.conf << OPENSDS_GLOBAL_CONFIG_DOC
+[osdslet]
+api_endpoint = 0.0.0.0:50040
+graceful = True
+log_file = /var/log/opensds/osdslet.log
+socket_order = inc
+auth_strategy = $OPENSDS_AUTH_STRATEGY
+
+[osdsdock]
+api_endpoint = $HOST_IP:50050
+log_file = /var/log/opensds/osdsdock.log
+# Specify which backends should be enabled, sample,ceph,cinder,lvm and so on.
+enabled_backends = $OPENSDS_BACKEND_LIST
+
+[database]
+endpoint = $HOST_IP:$ETCD_PORT,$HOST_IP:$ETCD_PEER_PORT
+driver = etcd
+
+OPENSDS_GLOBAL_CONFIG_DOC
+}
+
+osds::opensds::install(){
+    osds:opensds:configuration
+# Run osdsdock and osdslet daemon in background.
+(
+    cd ${OPENSDS_DIR}
+    sudo build/out/bin/osdslet --daemon --alsologtostderr
+    sudo build/out/bin/osdsdock --daemon --alsologtostderr
+
+    osds::echo_summary "Waiting for osdslet to come up."
+    osds::util::wait_for_url localhost:50040 "osdslet" 0.25 80
+    if [ $OPENSDS_AUTH_STRATEGY == "keystone" ]; then
+        local xtrace
+        xtrace=$(set +o | grep xtrace)
+        set +o xtrace
+        source $DEV_STACK_DIR/openrc admin admin
+        $xtrace
+    fi
+    export OPENSDS_AUTH_STRATEGY=$OPENSDS_AUTH_STRATEGY
+    export OPENSDS_ENDPOINT=http://localhost:50040
+    build/out/bin/osdsctl profile create '{"name": "default", "description": "default policy"}'
+    # Copy bash completion script to system.
+    cp ${OPENSDS_DIR}/osdsctl/completion/osdsctl.bash_completion /etc/bash_completion.d/
+
+    if [ $? == 0 ]; then
+    osds::echo_summary devsds installed successfully !!
+    fi
+)
+}
+
+osds::opensds::cleanup() {
+    OSDSLET_PID=$(pgrep osdslet)
+    OSDSDOCK_PID=$(pgrep osdsdock)
+    if [ ! -z "$OSDSLET_PID" ]; then
+        kill $OSDSLET_PID
+    fi
+    if [ ! -z "$OSDSDOCK_PID" ]; then
+        kill $OSDSDOCK_PID
+    fi
+}
+
+osds::opensds::uninstall(){
+     : # Do nothing
+}
+
+osds::opensds::uninstall_purge(){
+     : # Do nothing
+}
+
+# Restore xtrace
+$_XTRACE_OPENSDS

--- a/script/devsds/local.conf
+++ b/script/devsds/local.conf
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Copyright (c) 2017 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright (c) 2018 Huawei Technologies Co., Ltd. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,25 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Save trace setting
-_XTRACE_CEPH=$(set +o | grep xtrace)
-set +o xtrace
+# OpenSDS authentication strategy, can support keystone, noauth.
+OPENSDS_AUTH_STRATEGY=noauth
 
-osds::ceph::install(){
-     : # TODO
-}
+# OpenSDS storage backend list, separated by a comma, support lvm right now.
+OPENSDS_BACKEND_LIST=lvm
 
-osds::ceph::cleanup() {
-     : # TODO
-}
-
-osds::ceph::uninstall(){
-     : # TODO
-}
-
-osds::ceph::uninstall_purge(){
-     : # TODO
-}
-
-# Restore xtrace
-$_XTRACE_CEPH
+# Host Ip which is used to service ip binding, including osdslet, osdsdock, etcd, keystone etc.
+# If HOST_IP is not set, the script will use the ip of default gateway interface as the host ip.
+# HOST_IP=192.168.56.100

--- a/script/devsds/sdsrc
+++ b/script/devsds/sdsrc
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2018 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+source $TOP_DIR/local.conf
+
+# Global
+HOST_IP=${HOST_IP:-}
+HOST_IP=$(osds::util::get_default_host_ip "$HOST_IP" "inet")
+if [ "$HOST_IP" == "" ]; then
+    osds::util::die $LINENO "Could not determine host ip address.  See local.conf for suggestions on setting HOST_IP."
+fi
+
+# OpenSDS configuration.
+OPENSDS_VERSION=${OPENSDS_VERSION:-v1beta}
+#openstack authentication strategy, support 'noauth', 'keystone'.
+OPENSDS_AUTH_STRATEGY=${OPENSDS_AUTH_STRATEGY:-noauth}
+# OpenSDS service name in keystone.
+OPENSDS_SERVER_NAME=${OPENSDS_SERVER_NAME:-opensds}
+# OpenSDS backend list.
+OPENSDS_BACKEND_LIST=${OPENSDS_BACKEND_LIST:-lvm}
+
+# devstack keystone configuration
+STACK_GIT_BASE=${STACK_GIT_BASE:-https://git.openstack.org}
+STACK_USER_NAME=${STACK_USER_NAME:-stack}
+STACK_PASSWORD=${STACK_PASSWORD:-opensds@123}
+STACK_HOME=${STACK_HOME:-/opt/stack}
+STACK_BRANCH=${STACK_BRANCH:-stable/queens}
+DEV_STACK_DIR=$STACK_HOME/devstack
+
+# ETCD configuration
+ETCD_VERSION=${ETCD_VERSION:-3.2.0}
+ETCD_HOST=${ETCD_HOST:-$HOST_IP}
+ETCD_PORT=${ETCD_PORT:-62379}
+ETCD_PEER_PORT=${ETCD_PEER_PORT:-62380}
+ETCD_DIR=${OPT_DIR}/etcd
+ETCD_LOGFILE=${ETCD_DIR}/etcd.log
+ETCD_DATADIR=${ETCD_DIR}/data
+
+OPENSDS_ENABLED_SERVICES=opensds,etcd
+if [ $OPENSDS_AUTH_STRATEGY = keystone ];then
+    OPENSDS_ENABLED_SERVICES+=,keystone
+fi
+OPENSDS_ENABLED_SERVICES+=,$OPENSDS_BACKEND_LIST
+SUPPORT_SERVICES=keystone,lvm,ceph,etcd,opensds


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add keystone install feature in devsds

The devsds default authentication strategy is `noauth`,  so to test `keystone` you need to set the `OPENSDS_AUTH_STRATEGY` item to `keystone` in local.conf file.
Then you just execute script ' ./install' to install OpenSDS with keystone authentication.
If you get the following output, it means OpenSDS is installed successfully.
```
Execute commands blow to set up ENVs which are needed by OpenSDS CLI:
------------------------------------------------------------------
export OPENSDS_AUTH_STRATEGY=keystone
export OPENSDS_ENDPOINT=http://localhost:50040
source /opt/stack/devstack/openrc
------------------------------------------------------------------

Enjoy it !!
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```