### PR TITLE
Scheduler echancement: If the key is prefixed with a colon, then this key is not used to filter the pool

### DIFF
--- a/pkg/controller/selector/filter.go
+++ b/pkg/controller/selector/filter.go
@@ -87,7 +87,13 @@ func IsAvailablePool(filterReq map[string]interface{}, pool *model.StoragePoolSp
 	if nil != err {
 		return false, err
 	}
+
 	for key, reqValue := range filterReq {
+		if strings.HasPrefix(key, ":") {
+			log.Info("Because " + key + " is prefixed with a colon, it is not used to filter the pool")
+			continue
+		}
+
 		poolValue, ok := poolMap[key]
 		if !ok {
 			log.Info("pool: " + pool.Name + " doesn't provide capability: " + key)

--- a/pkg/controller/selector/filter_test.go
+++ b/pkg/controller/selector/filter_test.go
@@ -118,6 +118,17 @@ func TestIsAvailablePool(t *testing.T) {
 		t.Errorf("Expected %v, get %v", false, isAvailable)
 	}
 
+	delete(filterReq, "totalCapacity")
+	filterReq[":totalCapacity"] = "!= 200"
+	isAvailable, err = IsAvailablePool(filterReq, &SamplePools[1])
+	if nil != err {
+		t.Errorf("Expected %v, get %v", nil, err)
+	}
+
+	if true != isAvailable {
+		t.Errorf("Expected %v, get %v", false, isAvailable)
+	}
+
 }
 
 func TestMatch(t *testing.T) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
design spec [#7](https://github.com/opensds/design-specs/pull/7)
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
