### PR TITLE
Remove package get steps and add protoc cmd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,21 @@
-.PHONY: all build package osdsdock osdslet docker clean
+.PHONY: all build protoc osdsdock osdslet osdsctl docker clean
 
 all:build
 
 build:osdsdock osdslet osdsctl
 
-package:
-	go get github.com/opensds/opensds/cmd/osdslet
-	go get github.com/opensds/opensds/cmd/osdsdock
-	go get github.com/opensds/opensds/osdsctl
+protoc:
+	cd pkg/dock/proto && protoc --go_out=plugins=grpc:. dock.proto
 
-osdsdock:package
+osdsdock:
 	mkdir -p  ./build/out/bin/
 	go build -o ./build/out/bin/osdsdock github.com/opensds/opensds/cmd/osdsdock
 
-osdslet:package
+osdslet:
 	mkdir -p  ./build/out/bin/
 	go build -o ./build/out/bin/osdslet github.com/opensds/opensds/cmd/osdslet
 
-osdsctl:package
+osdsctl:
 	mkdir -p  ./build/out/bin/
 	go build -o ./build/out/bin/osdsctl github.com/opensds/opensds/osdsctl
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. Since all vendor packages have been put into vendor directory, there is no need to exeucte `go get` command to handle package dependency issue.
2. Add protoc command in makefile, so developer can simply update the dock.pb.go file by running the command `make protoc`

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
