### PR TITLE
add metadata into the whitelist for replication api

### DIFF
--- a/pkg/api/replication.go
+++ b/pkg/api/replication.go
@@ -36,7 +36,7 @@ type ReplicationPortal struct {
 var whiteListSimple = []string{"Id", "Name", "ReplicationStatus"}
 var whiteList = []string{"Id", "CreatedAt", "UpdatedAt", "Name", "Description", "AvailabilityZone", "ReplicationStatus",
 	"PrimaryVolumeId", "SecondaryVolumeId", "PrimaryReplicationDriverData", "SecondaryReplicationDriverData",
-	"ReplicationMode", "ReplicationPeriod", "ProfileId"}
+	"ReplicationMode", "ReplicationPeriod", "ProfileId", "Metadata"}
 
 func (this *ReplicationPortal) CreateReplication() {
 	if !policy.Authorize(this.Ctx, "replication:create") {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add metadta into the whitelist for replication api

In csi replication scenario, some info should be stored in replication metadata when in Create Volume steps, and the info can be fetched in ControllerPublish.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
