### PR TITLE
Add group for service project

### DIFF
--- a/script/devsds/lib/keystone.sh
+++ b/script/devsds/lib/keystone.sh
@@ -90,6 +90,9 @@ osds::keystone::create_user_and_endpoint(){
     . $DEV_STACK_DIR/openrc admin admin
     openstack user create --domain default --password $STACK_PASSWORD $OPENSDS_SERVER_NAME
     openstack role add --project service --user opensds admin
+    openstack group create service
+    openstack group add user service opensds
+    openstack role add service --project service --group service
     openstack service create --name opensds$OPENSDS_VERSION --description "OpenSDS Block Storage" opensds$OPENSDS_VERSION
     openstack endpoint create --region RegionOne opensds$OPENSDS_VERSION public http://$HOST_IP:50040/$OPENSDS_VERSION/%\(tenant_id\)s
     openstack endpoint create --region RegionOne opensds$OPENSDS_VERSION internal http://$HOST_IP:50040/$OPENSDS_VERSION/%\(tenant_id\)s


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

As we known keystone has an auth design on domain, project, role, user. To facilitate the use of keystone in devsds, we should unify and simplify the relationship of domain, project, role and user:

- domain uses default domain.
- each project has a group with anonymous name.
- each group is assigned with a role.
- users are added into group.

**Which issue this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
