### PR TITLE
Add Makefile in dashboard

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -1,0 +1,35 @@
+# Docker build usage:
+# 	docker build . -t opensdsio/dashboard:latest
+# Docker run usage:
+# 	docker run -d -p 8080:8080 opensdsio/dashboard:latest
+
+FROM ubuntu:16.04
+MAINTAINER Leon Wang <wanghui71leon@gmail.com>
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Download and install some packages.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  sudo \
+  wget \
+  make \
+  g++ \
+  nginx \
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean
+RUN wget --no-check-certificate https://deb.nodesource.com/setup_8.x \
+  && chmod +x setup_8.x && ./setup_8.x \
+  && apt-get install -y nodejs
+
+# Current directory is always /opt/dashboard.
+WORKDIR /opt/dashboard
+
+# Copy dashboard source code into container before running command.
+COPY ./ ./
+
+RUN chmod 755 ./image_builder.sh \
+  && sudo ./image_builder.sh
+RUN sudo ./image_builder.sh --rebuild
+
+# Define default command.
+CMD ["/usr/bin/nginx", "-g "daemon off;""]

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -32,4 +32,4 @@ RUN chmod 755 ./image_builder.sh \
 RUN sudo ./image_builder.sh --rebuild
 
 # Define default command.
-CMD ["/usr/bin/nginx", "-g "daemon off;""]
+CMD /usr/sbin/nginx -g "daemon off;"

--- a/dashboard/Makefile
+++ b/dashboard/Makefile
@@ -1,0 +1,53 @@
+# Copyright (c) 2018 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+IMAGE = opensdsio/dashboard
+VERSION := latest
+
+all:build
+.PHONY: all
+
+build:dashboard
+.PHONY: build
+
+dashboard:package
+	chmod +x ./image_builder.sh \
+	  && ./image_builder.sh
+.PHONY: dashboard
+
+package:
+	apt-get update && apt-get install -y --no-install-recommends \
+	  sudo \
+	  wget \
+	  make \
+	  g++ \
+	  nginx \
+	  && rm -rf /var/lib/apt/lists/* \
+	  && apt-get clean
+	wget --no-check-certificate https://deb.nodesource.com/setup_8.x \
+	  && chmod +x setup_8.x && ./setup_8.x \
+	  && apt-get install -y nodejs
+.PHONY: package
+
+docker:
+	docker build . -t $(IMAGE):$(VERSION)
+.PHONY: docker
+
+clean:
+	rm -rf /etc/nginx/sites-available/default /var/www/html/* ./dist warn=False
+	npm uninstall --unsafe-perm
+	npm uninstall --unsafe-perm -g @angular/cli@1.7.4
+	apt-get --purge remove -y nodejs \
+	  && rm -rf ./setup_8.x warn=False
+.PHONY: clean

--- a/dashboard/image_builder.sh
+++ b/dashboard/image_builder.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Copyright (c) 2018 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if [[ "X$1" == "X--rebuild" ]]; then
+	npm rebuild node-sass --force 
+fi
+
+npm install --unsafe-perm -g @angular/cli@1.7.4
+npm install --unsafe-perm
+ng build --prod
+
+cp -R ./dist/* /var/www/html/
+
+cat > /etc/nginx/sites-available/default <<EOF
+    server {
+        listen 8080 default_server;
+        listen [::]:8080 default_server;
+        root /var/www/html;
+        index index.html index.htm index.nginx-debian.html;
+        server_name _;
+        location /v3/ {
+            proxy_pass http://10.10.3.173/identity/v3/;
+        }
+        location /v1beta/ {
+            proxy_pass http://10.10.3.173:50040/v1beta/;
+        }
+    }
+EOF


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This patch is designed for simplify the installation work of OpenSDS dashboard.

By using Makefile under `dashboard` folder, it's easy for user to build the dashboard module:

* Using `make` command to build from source code
* Using `make docker` to build from container
* Using `make clean` to clean some installed packages

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
