### PR TITLE
Change the default port of dashboard service

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -1,7 +1,7 @@
 # Docker build usage:
 # 	docker build . -t opensdsio/dashboard:latest
 # Docker run usage:
-# 	docker run -d -p 8080:8080 opensdsio/dashboard:latest
+# 	docker run -d -p 8088:8088 opensdsio/dashboard:latest
 
 FROM ubuntu:16.04
 MAINTAINER Leon Wang <wanghui71leon@gmail.com>

--- a/dashboard/image_builder.sh
+++ b/dashboard/image_builder.sh
@@ -26,8 +26,8 @@ cp -R ./dist/* /var/www/html/
 
 cat > /etc/nginx/sites-available/default <<EOF
     server {
-        listen 8080 default_server;
-        listen [::]:8080 default_server;
+        listen 8088 default_server;
+        listen [::]:8088 default_server;
         root /var/www/html;
         index index.html index.htm index.nginx-debian.html;
         server_name _;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
 Because keystone uses 80 as default port in apach2 service and hyperkube process of kubernetes also uses 8080 port, so changing the default port to 8088 of dashboard service.
**Which issue this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
