### PR TITLE
 fix an error when delete volume

### DIFF
--- a/pkg/api/db.go
+++ b/pkg/api/db.go
@@ -236,7 +236,7 @@ func DeleteVolumeDBEntry(ctx *c.Context, in *model.VolumeSpec) error {
 			log.Error("when delete volume in db:", err)
 			return err
 		}
-		return fmt.Errorf("Volume %s can not be deleted, because its profile or pool is empty.", in.Id)
+		return nil
 	}
 
 	snaps, err := db.C.ListSnapshotsByVolumeId(ctx, in.Id)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
There is no error return to the cli when volume whoes profile id or pool id is empty was deleted.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
