### PR TITLE
Merge Aruba release documentation

### DIFF
--- a/docs/readthedocs/index.rst
+++ b/docs/readthedocs/index.rst
@@ -32,10 +32,11 @@ APIs, with the objective of providing applicaiton-oriented storage services.
    introduction/opensds-installer
 
 .. toctree::
-   :maxdepth: 3
+   :maxdepth: 2
    :caption: Installation
 
    installation/Local-Cluster-Installation
+   releases
 
 .. toctree::
    :maxdepth: 3

--- a/docs/readthedocs/releases.rst
+++ b/docs/readthedocs/releases.rst
@@ -1,10 +1,13 @@
-# Official Releases
+Official Releases
+=================
 
-## Aruba
+Aruba
+-----
 
-The OpenSDS Aruba release completed June 30, 2018. 
+The OpenSDS Aruba release completed June 30, 2018.
 
-### Features
+Features
+--------
 
 The Aruba release adds the following functionality:
 
@@ -26,8 +29,8 @@ The Aruba release adds the following functionality:
 The OpenSDS controller (Hotpot), the north bound plugins (Sushi), and the
 installer can be downloaded from here:
 
-[Hotpot](https://github.com/opensds/opensds/releases/tag/v0.2.0)
+`Hotpot <https://github.com/opensds/opensds/releases/tag/v0.2.0>`_
 
-[Sushi](https://github.com/opensds/nbp/releases/tag/v0.2.0)
+`Sushi <https://github.com/opensds/nbp/releases/tag/v0.2.0>`_
 
-[Installer](https://github.com/opensds/opensds-installer/releases/tag/v0.2.0)
+`Installer <https://github.com/opensds/opensds-installer/releases/tag/v0.2.0>`_

--- a/docs/readthedocs/releases.rst
+++ b/docs/readthedocs/releases.rst
@@ -1,0 +1,33 @@
+# Official Releases
+
+## Aruba
+
+The OpenSDS Aruba release completed June 30, 2018. 
+
+### Features
+
+The Aruba release adds the following functionality:
+
+* Array-based replication
+* Cinder compatible API
+* Containerized deployment
+* Controller API request filter
+* Create volume from snapshot
+* Dashboard UI interface
+* Extend volume support
+* Fibre channel protocol support
+* Host-based replication
+* Multi-tenancy support in the API
+* OpenStack Keystone authentication
+* Storage backend capabilities reporting
+* Storage pool capability reporting
+* Volume groups
+
+The OpenSDS controller (Hotpot), the north bound plugins (Sushi), and the
+installer can be downloaded from here:
+
+[Hotpot](https://github.com/opensds/opensds/releases/tag/v0.2.0)
+
+[Sushi](https://github.com/opensds/nbp/releases/tag/v0.2.0)
+
+[Installer](https://github.com/opensds/opensds-installer/releases/tag/v0.2.0)


### PR DESCRIPTION
**What this PR does / why we need it**:
This merges documentation updates for the official Aruba release.