### PR TITLE
Standardize some constants defined for all storage drivers

### DIFF
--- a/contrib/connector/fc/fc.go
+++ b/contrib/connector/fc/fc.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	fcDriver = "fc"
+	fcDriver = "fibre_channel"
 )
 
 type FC struct {

--- a/contrib/drivers/ceph/ceph.go
+++ b/contrib/drivers/ceph/ceph.go
@@ -304,7 +304,7 @@ func (d *Driver) InitializeConnection(opt *pb.CreateAttachmentOpts) (*model.Conn
 		return nil, err
 	}
 	return &model.ConnectionInfo{
-		DriverVolumeType: "rbd",
+		DriverVolumeType: RBDProtocol,
 		ConnectionData: map[string]interface{}{
 			"secret_type":  "ceph",
 			"name":         poolName + "/" + opensdsPrefix + opt.GetVolumeId(),

--- a/contrib/drivers/drbd/replication.go
+++ b/contrib/drivers/drbd/replication.go
@@ -15,6 +15,7 @@ package drbd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 
 	"github.com/LINBIT/godrbdutils"
@@ -22,7 +23,6 @@ import (
 	"github.com/opensds/opensds/contrib/drivers/utils/config"
 	pb "github.com/opensds/opensds/pkg/dock/proto"
 	"github.com/opensds/opensds/pkg/model"
-	"path/filepath"
 )
 
 // ReplicationDriver
@@ -87,9 +87,9 @@ func (r *ReplicationDriver) CreateReplication(opt *pb.CreateReplicationOpts) (*m
 	primaryVolID := opt.GetPrimaryVolumeId()
 	secondaryVolID := opt.GetSecondaryVolumeId()
 	path, _ := filepath.EvalSymlinks(primaryData["Mountpoint"])
-	primaryBackingDevice,_ :=filepath.Abs(path)
+	primaryBackingDevice, _ := filepath.Abs(path)
 	path, _ = filepath.EvalSymlinks(secondaryData["Mountpoint"])
-	secondaryBackingDevice,_ := filepath.Abs(path)
+	secondaryBackingDevice, _ := filepath.Abs(path)
 	log.Info(primaryBackingDevice, secondaryBackingDevice)
 	// as we use the same minors/ports in primary/secondary, make them a set:
 	usedPort := make(map[int]bool)

--- a/contrib/drivers/drivers.go
+++ b/contrib/drivers/drivers.go
@@ -26,6 +26,7 @@ import (
 	"github.com/opensds/opensds/contrib/drivers/huawei/dorado"
 	"github.com/opensds/opensds/contrib/drivers/lvm"
 	"github.com/opensds/opensds/contrib/drivers/openstack/cinder"
+	"github.com/opensds/opensds/contrib/drivers/utils/config"
 	pb "github.com/opensds/opensds/pkg/dock/proto"
 	"github.com/opensds/opensds/pkg/model"
 	sample "github.com/opensds/opensds/testutils/driver"
@@ -78,16 +79,16 @@ type VolumeDriver interface {
 func Init(resourceType string) VolumeDriver {
 	var d VolumeDriver
 	switch resourceType {
-	case "cinder":
+	case config.CinderDriverType:
 		d = &cinder.Driver{}
 		break
-	case "ceph":
+	case config.CephDriverType:
 		d = &ceph.Driver{}
 		break
-	case "lvm":
+	case config.LVMDriverType:
 		d = &lvm.Driver{}
 		break
-	case "huawei_dorado":
+	case config.HuaweiDoradoDriverType:
 		d = &dorado.Driver{}
 		break
 	default:

--- a/contrib/drivers/huawei/dorado/dorado.go
+++ b/contrib/drivers/huawei/dorado/dorado.go
@@ -17,9 +17,8 @@ package dorado
 import (
 	"errors"
 	"fmt"
-	"strings"
-
 	"os"
+	"strings"
 
 	log "github.com/golang/glog"
 	. "github.com/opensds/opensds/contrib/drivers/utils/config"
@@ -149,10 +148,10 @@ func (d *Driver) getTargetInfo() (string, string, error) {
 }
 
 func (d *Driver) InitializeConnection(opt *pb.CreateAttachmentOpts) (*model.ConnectionInfo, error) {
-	if opt.GetAccessProtocol() == "iscsi" {
+	if opt.GetAccessProtocol() == ISCSIProtocol {
 		return d.InitializeConnectionIscsi(opt)
 	}
-	if opt.GetAccessProtocol() == "fc" {
+	if opt.GetAccessProtocol() == FCProtocol {
 		return d.InitializeConnectionFC(opt)
 	}
 	return nil, errors.New("No supported protocol for dorado driver.")
@@ -200,7 +199,7 @@ func (d *Driver) InitializeConnectionIscsi(opt *pb.CreateAttachmentOpts) (*model
 		return nil, err
 	}
 	connInfo := &model.ConnectionInfo{
-		DriverVolumeType: "iscsi",
+		DriverVolumeType: ISCSIProtocol,
 		ConnectionData: map[string]interface{}{
 			"targetDiscovered": true,
 			"targetIQN":        tgtIqn,
@@ -213,10 +212,10 @@ func (d *Driver) InitializeConnectionIscsi(opt *pb.CreateAttachmentOpts) (*model
 }
 
 func (d *Driver) TerminateConnection(opt *pb.DeleteAttachmentOpts) error {
-	if opt.GetAccessProtocol() == "iscsi" {
+	if opt.GetAccessProtocol() == ISCSIProtocol {
 		return d.TerminateConnectionIscsi(opt)
 	}
-	if opt.GetAccessProtocol() == "fc" {
+	if opt.GetAccessProtocol() == FCProtocol {
 		return d.TerminateConnectionFC(opt)
 	}
 	return nil
@@ -368,7 +367,7 @@ func (d *Driver) InitializeConnectionFC(opt *pb.CreateAttachmentOpts) (*model.Co
 	}
 
 	fcInfo := &model.ConnectionInfo{
-		DriverVolumeType: "fibre_channel",
+		DriverVolumeType: FCProtocol,
 		ConnectionData: map[string]interface{}{
 			"targetDiscovered":     true,
 			"target_wwn":           tgtPortWWNs,

--- a/contrib/drivers/lvm/lvm.go
+++ b/contrib/drivers/lvm/lvm.go
@@ -370,7 +370,7 @@ func (d *Driver) InitializeConnection(opt *pb.CreateAttachmentOpts) (*model.Conn
 	}
 
 	return &model.ConnectionInfo{
-		DriverVolumeType: "iscsi",
+		DriverVolumeType: ISCSIProtocol,
 		ConnectionData:   expt,
 	}, nil
 }

--- a/contrib/drivers/replication_drivers.go
+++ b/contrib/drivers/replication_drivers.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/opensds/opensds/contrib/drivers/drbd"
 	"github.com/opensds/opensds/contrib/drivers/huawei/dorado"
+	driversConfig "github.com/opensds/opensds/contrib/drivers/utils/config"
 	pb "github.com/opensds/opensds/pkg/dock/proto"
 	"github.com/opensds/opensds/pkg/model"
 	"github.com/opensds/opensds/pkg/utils/config"
@@ -64,10 +65,10 @@ func IsSupportHostBasedReplication(resourceType string) bool {
 func InitReplicationDriver(resourceType string) (ReplicationDriver, error) {
 	var d ReplicationDriver
 	switch resourceType {
-	case "drbd":
+	case driversConfig.DRBDDriverType:
 		d = &drbd.ReplicationDriver{}
 		break
-	case "huawei_dorado":
+	case driversConfig.HuaweiDoradoDriverType:
 		d = &dorado.ReplicationDriver{}
 		break
 	default:

--- a/contrib/drivers/utils/config/config.go
+++ b/contrib/drivers/utils/config/config.go
@@ -12,6 +12,11 @@
 //    License for the specific language governing permissions and limitations
 //    under the License.
 
+/*
+This module defines some essential configuration infos for all storage drivers.
+
+*/
+
 package config
 
 import (

--- a/contrib/drivers/utils/config/constants.go
+++ b/contrib/drivers/utils/config/constants.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2018 Huawei Technologies Co., Ltd. All Rights Reserved.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License"); you may
+//    not use this file except in compliance with the License. You may obtain
+//    a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+//    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+//    License for the specific language governing permissions and limitations
+//    under the License.
+
+/*
+This module defines some essential configuration infos for all storage drivers.
+
+*/
+
+package config
+
+// These constants below represent the vendor name of all storage drivers which
+// can be supported by now.
+const (
+	CinderDriverType       = "cinder"
+	CephDriverType         = "ceph"
+	LVMDriverType          = "lvm"
+	HuaweiDoradoDriverType = "huawei_dorado"
+
+	DRBDDriverType = "drbd"
+)
+
+// These constants below represent the access protocol type of all storage
+// drivers which can be supported by now. Please NOTICE that currently these
+// constants can NOT be used by all methods except InitializeConnection().
+const (
+	ISCSIProtocol = "iscsi"
+	RBDProtocol   = "rbd"
+	FCProtocol    = "fibre_channel"
+)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
In southbound drivers module, it's too disorganized that we define many string constants randomly. So this patch is designed for keeping all constants defined in drivers module at one place.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
