### PR TITLE
Add dist make target for build packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /bin
+build/
 *.log
 .DS_Store
 *.retry

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ env:
   - secure: "IhEskTMEAsBNYTQCpDSlvDxIJK5cu1r2V"
 
 before_install:
+  - sudo apt-get update
+  - sudo apt-get install -y build-essential gcc
+  - sudo apt-get install -y librados-dev librbd-dev
   - sudo apt-get install -y lvm2 tgt open-iscsi
 
 matrix:


### PR DESCRIPTION
This is part of an effort to standardize how builds are done
across OpenSDS projects. Adding a common "dist" make target
so build artifacts can more easily be collected across the
different deliverables.

Signed-off-by: Sean McGinnis <sean.mcginnis@gmail.com>
