### PR TITLE
TestVolumeActionInitializeConnectionWithError in contrib/cindercompaibleapi/api/volume_test.go should modify sleep call

### DIFF
--- a/contrib/cindercompatibleapi/api/volume.go
+++ b/contrib/cindercompatibleapi/api/volume.go
@@ -39,6 +39,11 @@ type VolumePortal struct {
 	beego.Controller
 }
 
+var (
+	// SleepDuration When running unit tests, it should be set to time.Nanosecond
+	SleepDuration = time.Second
+)
+
 // ListVolumesDetails ...
 func (portal *VolumePortal) ListVolumesDetails() {
 	volumes, err := client.ListVolumes()
@@ -278,7 +283,7 @@ func (portal *VolumePortal) VolumeAction() {
 
 		for {
 			sum++
-			time.Sleep(1e9)
+			time.Sleep(SleepDuration)
 			attachment, _ = client.GetVolumeAttachment(attachment.Id)
 			if ("available" == attachment.Status) && ("" != attachment.ConnectionInfo.DriverVolumeType) &&
 				//(nil != attachment.ConnectionInfo.ConnectionData["authPassword"]) &&

--- a/contrib/cindercompatibleapi/api/volume_test.go
+++ b/contrib/cindercompatibleapi/api/volume_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/astaxie/beego"
 	c "github.com/opensds/opensds/client"
@@ -380,6 +381,7 @@ func TestVolumeAction(t *testing.T) {
 }
 
 func TestVolumeActionInitializeConnectionWithError(t *testing.T) {
+	SleepDuration = time.Nanosecond
 	Req := converter.InitializeConnectionReqSpec{}
 
 	Req.InitializeConnection.Connector.Platform = "x86_64"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
TestVolumeActionInitializeConnectionWithError in contrib/cindercompaibleapi/api/volume_test.go should modify sleep call.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Solve Issue [#504](https://github.com/opensds/opensds/issues/504)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
