### PR TITLE
Fixed get fs parsing bug

### DIFF
--- a/contrib/connector/iscsi/helper.go
+++ b/contrib/connector/iscsi/helper.go
@@ -269,7 +269,8 @@ func GetFSType(device string) string {
 		for _, v := range strings.Split(string(res), " ") {
 			if strings.Contains(v, "TYPE=") {
 				fsType = strings.Split(v, "=")[1]
-				fsType = strings.Replace(fsType, "\"", "", -1)
+				fsType = strings.TrimSpace(fsType)
+				fsType = strings.Trim(fsType, "\"")
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
GetFsType does not trim the '\n' character,  this will lead a bug in csi, so trim it first.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
