### PR TITLE
make log flushing shorter, and fixed some flag bugs

### DIFF
--- a/cmd/osdsdock/osdsdock.go
+++ b/cmd/osdsdock/osdsdock.go
@@ -30,12 +30,13 @@ import (
 
 func init() {
 	def := GetDefaultConfig()
-	flag := CONF.Flag
+	flag := &CONF.Flag
 	flag.StringVar(&CONF.OsdsDock.ApiEndpoint, "api-endpoint", def.OsdsDock.ApiEndpoint, "Listen endpoint of dock service")
 	flag.StringVar(&CONF.OsdsDock.DockType, "dock-type", def.OsdsDock.DockType, "Type of dock service")
 	flag.StringVar(&CONF.Database.Endpoint, "db-endpoint", def.Database.Endpoint, "Connection endpoint of database service")
 	flag.StringVar(&CONF.Database.Driver, "db-driver", def.Database.Driver, "Driver name of database service")
 	// flag.StringVar(&CONF.Database.Credential, "db-credential", def.Database.Credential, "Connection credential of database service")
+	flag.DurationVar(&CONF.OsdsLet.LogFlushFrequency, "log-flush-frequency", def.OsdsLet.LogFlushFrequency, "Maximum number of seconds between log flushes")
 	daemon.SetDaemonFlag(&CONF.OsdsDock.Daemon, def.OsdsDock.Daemon)
 	CONF.Load("/etc/opensds/opensds.conf")
 	daemon.CheckAndRunDaemon(CONF.OsdsDock.Daemon)

--- a/cmd/osdslet/osdslet.go
+++ b/cmd/osdslet/osdslet.go
@@ -30,11 +30,12 @@ import (
 
 func init() {
 	def := GetDefaultConfig()
-	flag := CONF.Flag
+	flag := &CONF.Flag
 	flag.StringVar(&CONF.OsdsLet.ApiEndpoint, "api-endpoint", def.OsdsLet.ApiEndpoint, "Listen endpoint of controller service")
 	flag.StringVar(&CONF.Database.Endpoint, "db-endpoint", def.Database.Endpoint, "Connection endpoint of database service")
 	flag.StringVar(&CONF.Database.Driver, "db-driver", def.Database.Driver, "Driver name of database service")
 	flag.StringVar(&CONF.Database.Credential, "db-credential", def.Database.Credential, "Connection credential of database service")
+	flag.DurationVar(&CONF.OsdsLet.LogFlushFrequency, "log-flush-frequency", def.OsdsLet.LogFlushFrequency, "Maximum number of seconds between log flushes")
 	daemon.SetDaemonFlag(&CONF.OsdsLet.Daemon, def.OsdsLet.Daemon)
 	CONF.Load("/etc/opensds/opensds.conf")
 	daemon.CheckAndRunDaemon(CONF.OsdsLet.Daemon)

--- a/pkg/api/filter/accesslog/accesslog.go
+++ b/pkg/api/filter/accesslog/accesslog.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2017 Huawei Technologies Co., Ltd. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package accesslog
+
+import (
+	"github.com/astaxie/beego"
+	bctx "github.com/astaxie/beego/context"
+	"github.com/golang/glog"
+)
+
+func Factory() beego.FilterFunc {
+	return func(httpCtx *bctx.Context) {
+		r := httpCtx.Request
+		glog.Infof("\033[32m[D] %s -- %s %s\033[0m\n", r.RemoteAddr, r.Method,
+			r.URL)
+	}
+}

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/astaxie/beego"
 	bctx "github.com/astaxie/beego/context"
+	"github.com/opensds/opensds/pkg/api/filter/accesslog"
 	"github.com/opensds/opensds/pkg/api/filter/auth"
 	"github.com/opensds/opensds/pkg/api/filter/context"
 	"github.com/opensds/opensds/pkg/utils/constants"
@@ -103,6 +104,7 @@ func Run(host string) {
 	pattern := fmt.Sprintf("/%s/*", constants.APIVersion)
 	beego.InsertFilter(pattern, beego.BeforeExec, context.Factory())
 	beego.InsertFilter(pattern, beego.BeforeExec, auth.Factory())
+	beego.InsertFilter("*", beego.BeforeExec, accesslog.Factory())
 	beego.AddNamespace(ns)
 
 	// add router for api version

--- a/pkg/utils/config/config_define.go
+++ b/pkg/utils/config/config_define.go
@@ -14,15 +14,18 @@
 
 package config
 
+import "time"
+
 type Default struct{}
 
 type OsdsLet struct {
-	ApiEndpoint  string `conf:"api_endpoint,localhost:50040"`
-	Graceful     bool   `conf:"graceful,true"`
-	SocketOrder  string `conf:"socket_order"`
-	AuthStrategy string `conf:"auth_strategy,noauth"`
-	Daemon       bool   `conf:"daemon,false"`
-	PolicyPath   string `conf:"policy_path,/etc/opensds/policy.json"`
+	ApiEndpoint       string        `conf:"api_endpoint,localhost:50040"`
+	Graceful          bool          `conf:"graceful,true"`
+	SocketOrder       string        `conf:"socket_order"`
+	AuthStrategy      string        `conf:"auth_strategy,noauth"`
+	Daemon            bool          `conf:"daemon,false"`
+	PolicyPath        string        `conf:"policy_path,/etc/opensds/policy.json"`
+	LogFlushFrequency time.Duration `conf:"log_flush_frequency,5000000000"` // Default value is 5s
 }
 
 type OsdsDock struct {

--- a/pkg/utils/config/flag.go
+++ b/pkg/utils/config/flag.go
@@ -17,8 +17,7 @@ package config
 import (
 	gflag "flag"
 	"reflect"
-
-	log "github.com/golang/glog"
+	"time"
 )
 
 type Flag struct {
@@ -83,6 +82,13 @@ func (f *FlagSet) StringVar(p *string, name string, defValue string, usage strin
 	f.Add(name, flag)
 }
 
+func (f *FlagSet) DurationVar(p *time.Duration, name string, defValue time.Duration, usage string) {
+	inVal := new(time.Duration)
+	flag := &Flag{Value: p, InValue: inVal}
+	gflag.DurationVar(inVal, name, defValue, usage)
+	f.Add(name, flag)
+}
+
 func (f *FlagSet) Add(name string, flag *Flag) {
 	if f.flagMap == nil {
 		f.flagMap = make(map[string]*Flag)
@@ -103,25 +109,8 @@ func (f *FlagSet) AssignValue() {
 		if _, ok := f.flagMap[name]; !ok {
 			continue
 		}
-		typ := reflect.TypeOf(f.flagMap[name].InValue)
-		val := reflect.ValueOf(f.flagMap[name].InValue)
-		switch typ.Elem().Kind() {
-		case reflect.String:
-			*f.flagMap[name].Value.(*string) = val.Elem().String()
-		case reflect.Bool:
-			*f.flagMap[name].Value.(*bool) = val.Elem().Bool()
-		case reflect.Int:
-			*f.flagMap[name].Value.(*int) = int(val.Elem().Int())
-		case reflect.Int64:
-			*f.flagMap[name].Value.(*int64) = val.Elem().Int()
-		case reflect.Uint:
-			*f.flagMap[name].Value.(*uint) = uint(val.Elem().Uint())
-		case reflect.Uint64:
-			*f.flagMap[name].Value.(*uint64) = val.Elem().Uint()
-		case reflect.Float64:
-			*f.flagMap[name].Value.(*float64) = val.Elem().Float()
-		default:
-			log.Error("Flag do not support this type.")
-		}
+		iv := reflect.ValueOf(f.flagMap[name].InValue).Elem()
+		v := reflect.ValueOf(f.flagMap[name].Value).Elem()
+		v.Set(iv)
 	}
 }

--- a/pkg/utils/logs/logs.go
+++ b/pkg/utils/logs/logs.go
@@ -18,12 +18,24 @@ import (
 	"flag"
 	"log"
 	"os"
+	"time"
 
+	"fmt"
 	"github.com/golang/glog"
 	"github.com/opensds/opensds/pkg/utils"
+	"github.com/opensds/opensds/pkg/utils/config"
+	"os/signal"
+	"syscall"
 )
 
 const DefaultLogDir = "/var/log/opensds"
+
+// flushDaemon periodically flushes the log file buffers.
+func flushDaemon(period time.Duration) {
+	for _ = range time.NewTicker(period).C {
+		glog.Flush()
+	}
+}
 
 func init() {
 	//Set OpenSDS default log directory.
@@ -42,6 +54,18 @@ func (writer GlogWriter) Write(data []byte) (n int, err error) {
 	return len(data), nil
 }
 
+// flush log when be interrupted.
+func handleInterrupt() {
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM, syscall.SIGKILL, syscall.SIGQUIT)
+	go func() {
+		sig := <-sigs
+		fmt.Println(sig)
+		FlushLogs()
+		os.Exit(-1)
+	}()
+}
+
 func InitLogs() {
 	log.SetOutput(GlogWriter{})
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
@@ -49,6 +73,8 @@ func InitLogs() {
 	if exist, _ := utils.PathExists(logDir); !exist {
 		os.MkdirAll(logDir, 0755)
 	}
+	go flushDaemon(config.CONF.LogFlushFrequency)
+	handleInterrupt()
 }
 
 func FlushLogs() {

--- a/pkg/utils/logs/logs.go
+++ b/pkg/utils/logs/logs.go
@@ -16,16 +16,16 @@ package logs
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
-	"fmt"
 	"github.com/golang/glog"
 	"github.com/opensds/opensds/pkg/utils"
 	"github.com/opensds/opensds/pkg/utils/config"
-	"os/signal"
-	"syscall"
 )
 
 const DefaultLogDir = "/var/log/opensds"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. Make log flushing shorter(5s), and user can set it using flag "-log-flush-frequency", for example:
```
osdsdock -log-flush-frequency 2s
```
2. Fixed some flags donot work bug.

3. Add osdslet access log.

4. Flushing log when opensds exit.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
