### PR TITLE
add keystone auth for multi-cloud and add retry mechanism

### DIFF
--- a/contrib/backup/multicloud/driver_test.go
+++ b/contrib/backup/multicloud/driver_test.go
@@ -32,10 +32,17 @@ func TestLoadConf(t *testing.T) {
 	}
 	expect := &MultiCloudConf{
 		Endpoint:      "http://127.0.0.1:8088",
-		TenantId:      "FakeTenantId",
 		UploadTimeout: DefaultUploadTimeout,
+		AuthOptions: AuthOptions{
+			Strategy:   "keystone",
+			AuthUrl:    "http://127.0.0.1/identity",
+			DomainName: "Default",
+			UserName:   "admin",
+			Password:   "opensds@123",
+			TenantName: "admin",
+		},
 	}
-	fmt.Println(conf)
+	fmt.Printf("%+v", conf)
 	if !reflect.DeepEqual(expect, conf) {
 		t.Errorf("load conf file error")
 	}

--- a/contrib/backup/multicloud/testdata/multi-cloud.yaml
+++ b/contrib/backup/multicloud/testdata/multi-cloud.yaml
@@ -1,4 +1,10 @@
 "Endpoint": "http://127.0.0.1:8088"
-"TenantId": "FakeTenantId"
 # upload object timeout in seconds
 "UploadTimeout": 30
+AuthOptions:
+  Strategy: "keystone"
+  AuthUrl: "http://127.0.0.1/identity"
+  DomainName: "Default"
+  UserName: "admin"
+  Password: "opensds@123"
+  TenantName: "admin"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

1. add keystone auth for multi-cloud, configuration should be like this:
```
"Endpoint": "http://127.0.0.1:8088"
# upload object timeout in seconds
"UploadTimeout": 30
AuthOptions:
  Strategy: "keystone"
  AuthUrl: "http://127.0.0.1/identity"
  DomainName: "Default"
  UserName: "admin"
  Password: "opensds@123"
  TenantName: "admin"
```
2. add retry mechanism

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
