### PR TITLE
When the https request returns a StatusUnauthorized error code, the tenantID in the url is not actually modified.

### DIFF
--- a/client/auth.go
+++ b/client/auth.go
@@ -39,6 +39,7 @@ const (
 
 type AuthOptions interface {
 	GetTenantId() string
+	GetTokenId() string
 }
 
 func NewKeystoneAuthOptions() *KeystoneAuthOptions {
@@ -62,6 +63,18 @@ func (k *KeystoneAuthOptions) GetTenantId() string {
 	return k.TenantID
 }
 
+func (k *KeystoneAuthOptions) GetTokenId() string {
+	return k.TokenID
+}
+
+func (k *KeystoneAuthOptions) SetTenantId(tenantId string) {
+	k.TenantID = tenantId
+}
+
+func (k *KeystoneAuthOptions) SetTokenId(tokenId string) {
+	k.TokenID = tokenId
+}
+
 func NewNoauthOptions(tenantId string) *NoAuthOptions {
 	return &NoAuthOptions{TenantID: tenantId}
 }
@@ -74,6 +87,15 @@ func (n *NoAuthOptions) GetTenantId() string {
 	return n.TenantID
 }
 
+func (n *NoAuthOptions) GetTokenId() string {
+	return ""
+}
+
+func (n *NoAuthOptions) SetTenantId(tenantId string) {
+	n.TenantID = tenantId
+}
+
+func (n *NoAuthOptions) SetTokenId() {}
 func LoadKeystoneAuthOptionsFromEnv() *KeystoneAuthOptions {
 	opt := NewKeystoneAuthOptions()
 	opt.IdentityEndpoint = os.Getenv(OsAuthUrl)

--- a/client/dock.go
+++ b/client/dock.go
@@ -15,33 +15,25 @@
 package client
 
 import (
-	"strings"
-
 	"github.com/opensds/opensds/pkg/model"
 	"github.com/opensds/opensds/pkg/utils/urls"
 )
 
-func NewDockMgr(r Receiver, edp string, tenantId string) *DockMgr {
+func NewDockMgr(r Receiver, edp string) *DockMgr {
 	return &DockMgr{
 		Receiver: r,
 		Endpoint: edp,
-		TenantId: tenantId,
 	}
 }
 
 type DockMgr struct {
 	Receiver
 	Endpoint string
-	TenantId string
 }
 
 func (d *DockMgr) GetDock(dckID string) (*model.DockSpec, error) {
 	var res model.DockSpec
-	url := strings.Join([]string{
-		d.Endpoint,
-		urls.GenerateDockURL(urls.Client, d.TenantId, dckID)}, "/")
-
-	if err := d.Recv(url, "GET", nil, &res); err != nil {
+	if err := d.Receiver.Recv(urls.DockResource, d.Endpoint, "GET", nil, &res); err != nil {
 		return nil, err
 	}
 
@@ -50,21 +42,17 @@ func (d *DockMgr) GetDock(dckID string) (*model.DockSpec, error) {
 
 func (d *DockMgr) ListDocks(args ...interface{}) ([]*model.DockSpec, error) {
 	var res []*model.DockSpec
-
-	url := strings.Join([]string{
-		d.Endpoint,
-		urls.GenerateDockURL(urls.Client, d.TenantId)}, "/")
-
+	var filter string
 	param, err := processListParam(args)
 	if err != nil {
 		return nil, err
 	}
 
 	if param != "" {
-		url += "?" + param
+		filter += "?" + param
 	}
 
-	if err := d.Recv(url, "GET", nil, &res); err != nil {
+	if err := d.Receiver.Recv(urls.DockResource, d.Endpoint, "GET", nil, &res, filter); err != nil {
 		return nil, err
 	}
 

--- a/client/dock_test.go
+++ b/client/dock_test.go
@@ -25,6 +25,16 @@ var fd = &DockMgr{
 	Receiver: NewFakeDockReceiver(),
 }
 
+func init() {
+	config = &Config{
+		Endpoint: "fakeEndpoint",
+		AuthOptions: &KeystoneAuthOptions{
+			TenantID: "0105e3e4d44d40b59472688a3f28d469",
+			TokenID:  "MIIDcQYJKoZIhvcNAQcCoIIDYjCCA14CAQ",
+		},
+	}
+}
+
 func TestGetDock(t *testing.T) {
 	var dckID = "b7602e18-771e-11e7-8f38-dbd6d291f4e0"
 	expected := &model.DockSpec{

--- a/client/fake.go
+++ b/client/fake.go
@@ -27,21 +27,14 @@ import (
 
 var (
 	fakeClient *Client
-	fakeConfig *Config
 	once       sync.Once
 	TestEp     = "TestEndPoint"
 )
 
-func NewFakeClient(config *Config) *Client {
+func NewFakeClient(c *Config) *Client {
 	once.Do(func() {
-		os.Setenv("OPENSDS_ENDPOINT", config.Endpoint)
-		fakeConfig = &Config{
-			Endpoint: config.Endpoint,
-			AuthOptions: &KeystoneAuthOptions{
-				TenantID: "0105e3e4d44d40b59472688a3f28d469",
-				TokenID:  "MIIDcQYJKoZIhvcNAQcCoIIDYjCCA14CAQ",
-			},
-		}
+		os.Setenv("OPENSDS_ENDPOINT", c.Endpoint)
+		config = c
 		fakeClient = &Client{
 			ProfileMgr: &ProfileMgr{
 				Receiver: NewFakeProfileReceiver(),

--- a/client/fake.go
+++ b/client/fake.go
@@ -27,6 +27,7 @@ import (
 
 var (
 	fakeClient *Client
+	fakeConfig *Config
 	once       sync.Once
 	TestEp     = "TestEndPoint"
 )
@@ -34,30 +35,31 @@ var (
 func NewFakeClient(config *Config) *Client {
 	once.Do(func() {
 		os.Setenv("OPENSDS_ENDPOINT", config.Endpoint)
+		fakeConfig = &Config{
+			Endpoint: config.Endpoint,
+			AuthOptions: &KeystoneAuthOptions{
+				TenantID: "0105e3e4d44d40b59472688a3f28d469",
+				TokenID:  "MIIDcQYJKoZIhvcNAQcCoIIDYjCCA14CAQ",
+			},
+		}
 		fakeClient = &Client{
 			ProfileMgr: &ProfileMgr{
 				Receiver: NewFakeProfileReceiver(),
-				Endpoint: config.Endpoint,
 			},
 			DockMgr: &DockMgr{
 				Receiver: NewFakeDockReceiver(),
-				Endpoint: config.Endpoint,
 			},
 			PoolMgr: &PoolMgr{
 				Receiver: NewFakePoolReceiver(),
-				Endpoint: config.Endpoint,
 			},
 			VolumeMgr: &VolumeMgr{
 				Receiver: NewFakeVolumeReceiver(),
-				Endpoint: config.Endpoint,
 			},
 			ReplicationMgr: &ReplicationMgr{
 				Receiver: NewFakeReplicationReceiver(),
-				Endpoint: config.Endpoint,
 			},
 			VersionMgr: &VersionMgr{
 				Receiver: NewFakeVersionReceiver(),
-				Endpoint: config.Endpoint,
 			},
 		}
 	})

--- a/client/pool.go
+++ b/client/pool.go
@@ -22,11 +22,10 @@ import (
 )
 
 // NewPoolMgr
-func NewPoolMgr(r Receiver, edp string, tenantId string) *PoolMgr {
+func NewPoolMgr(r Receiver, edp string) *PoolMgr {
 	return &PoolMgr{
 		Receiver: r,
 		Endpoint: edp,
-		TenantId: tenantId,
 	}
 }
 
@@ -34,17 +33,12 @@ func NewPoolMgr(r Receiver, edp string, tenantId string) *PoolMgr {
 type PoolMgr struct {
 	Receiver
 	Endpoint string
-	TenantId string
 }
 
 // GetPool
 func (p *PoolMgr) GetPool(polID string) (*model.StoragePoolSpec, error) {
 	var res model.StoragePoolSpec
-	url := strings.Join([]string{
-		p.Endpoint,
-		urls.GeneratePoolURL(urls.Client, p.TenantId, polID)}, "/")
-
-	if err := p.Recv(url, "GET", nil, &res); err != nil {
+	if err := p.Receiver.Recv(urls.PoolResource, p.Endpoint, "GET", nil, &res, polID); err != nil {
 		return nil, err
 	}
 
@@ -54,21 +48,17 @@ func (p *PoolMgr) GetPool(polID string) (*model.StoragePoolSpec, error) {
 // ListPools
 func (p *PoolMgr) ListPools(args ...interface{}) ([]*model.StoragePoolSpec, error) {
 	var res []*model.StoragePoolSpec
-
-	url := strings.Join([]string{
-		p.Endpoint,
-		urls.GeneratePoolURL(urls.Client, p.TenantId)}, "/")
-
+	var filter string
 	param, err := processListParam(args)
 	if err != nil {
 		return nil, err
 	}
 
 	if param != "" {
-		url += "?" + param
+		filter += "?" + param
 	}
 
-	if err := p.Recv(url, "GET", nil, &res); err != nil {
+	if err := p.Receiver.Recv(urls.PoolResource, p.Endpoint, "GET", nil, &res, filter); err != nil {
 		return nil, err
 	}
 

--- a/client/profile.go
+++ b/client/profile.go
@@ -33,23 +33,25 @@ type ProfileBuilder *model.ProfileSpec
 type CustomBuilder *model.CustomPropertiesSpec
 
 // NewProfileMgr
-func NewProfileMgr(r Receiver, edp string) *ProfileMgr {
+func NewProfileMgr(r Receiver) *ProfileMgr {
 	return &ProfileMgr{
 		Receiver: r,
-		Endpoint: edp,
 	}
 }
 
 // ProfileMgr
 type ProfileMgr struct {
 	Receiver
-	Endpoint string
 }
 
 // CreateProfile
 func (p *ProfileMgr) CreateProfile(body ProfileBuilder) (*model.ProfileSpec, error) {
 	var res model.ProfileSpec
-	if err := p.Receiver.Recv(urls.ProfileResource, p.Endpoint, "POST", body, &res); err != nil {
+	url := strings.Join([]string{
+		config.Endpoint,
+		urls.GenerateProfileURL(urls.Client, config.AuthOptions.GetTenantId())}, "/")
+
+	if err := p.Recv(url, "POST", body, &res); err != nil {
 		return nil, err
 	}
 
@@ -59,8 +61,11 @@ func (p *ProfileMgr) CreateProfile(body ProfileBuilder) (*model.ProfileSpec, err
 // GetProfile
 func (p *ProfileMgr) GetProfile(prfID string) (*model.ProfileSpec, error) {
 	var res model.ProfileSpec
+	url := strings.Join([]string{
+		config.Endpoint,
+		urls.GenerateProfileURL(urls.Client, config.AuthOptions.GetTenantId(), prfID)}, "/")
 
-	if err := p.Receiver.Recv(urls.ProfileResource, p.Endpoint, "GET", nil, &res, "", prfID); err != nil {
+	if err := p.Recv(url, "GET", nil, &res); err != nil {
 		return nil, err
 	}
 
@@ -70,8 +75,11 @@ func (p *ProfileMgr) GetProfile(prfID string) (*model.ProfileSpec, error) {
 // UpdateProfile ...
 func (p *ProfileMgr) UpdateProfile(prfID string, body ProfileBuilder) (*model.ProfileSpec, error) {
 	var res model.ProfileSpec
+	url := strings.Join([]string{
+		config.Endpoint,
+		urls.GenerateProfileURL(urls.Client, config.AuthOptions.GetTenantId(), prfID)}, "/")
 
-	if err := p.Receiver.Recv(urls.ProfileResource, p.Endpoint, "PUT", body, &res, "", prfID); err != nil {
+	if err := p.Recv(url, "PUT", body, &res); err != nil {
 		return nil, err
 	}
 
@@ -83,8 +91,8 @@ func (p *ProfileMgr) ListProfiles(args ...interface{}) ([]*model.ProfileSpec, er
 	var res []*model.ProfileSpec
 
 	url := strings.Join([]string{
-		p.Endpoint,
-		urls.GenerateProfileURL(urls.Client, p.TenantId)}, "/")
+		config.Endpoint,
+		urls.GenerateProfileURL(urls.Client, config.AuthOptions.GetTenantId())}, "/")
 
 	param, err := processListParam(args)
 	if err != nil {
@@ -104,8 +112,8 @@ func (p *ProfileMgr) ListProfiles(args ...interface{}) ([]*model.ProfileSpec, er
 // DeleteProfile
 func (p *ProfileMgr) DeleteProfile(prfID string) error {
 	url := strings.Join([]string{
-		p.Endpoint,
-		urls.GenerateProfileURL(urls.Client, p.TenantId, prfID)}, "/")
+		config.Endpoint,
+		urls.GenerateProfileURL(urls.Client, config.AuthOptions.GetTenantId(), prfID)}, "/")
 
 	return p.Recv(url, "DELETE", nil, nil)
 }
@@ -114,8 +122,8 @@ func (p *ProfileMgr) DeleteProfile(prfID string) error {
 func (p *ProfileMgr) AddCustomProperty(prfID string, body CustomBuilder) (*model.CustomPropertiesSpec, error) {
 	var res model.CustomPropertiesSpec
 	url := strings.Join([]string{
-		p.Endpoint,
-		urls.GenerateProfileURL(urls.Client, p.TenantId, prfID),
+		config.Endpoint,
+		urls.GenerateProfileURL(urls.Client, config.AuthOptions.GetTenantId(), prfID),
 		"customProperties"}, "/")
 
 	if err := p.Recv(url, "POST", body, &res); err != nil {
@@ -129,8 +137,8 @@ func (p *ProfileMgr) AddCustomProperty(prfID string, body CustomBuilder) (*model
 func (p *ProfileMgr) ListCustomProperties(prfID string) (*model.CustomPropertiesSpec, error) {
 	var res model.CustomPropertiesSpec
 	url := strings.Join([]string{
-		p.Endpoint,
-		urls.GenerateProfileURL(urls.Client, p.TenantId, prfID),
+		config.Endpoint,
+		urls.GenerateProfileURL(urls.Client, config.AuthOptions.GetTenantId(), prfID),
 		"customProperties"}, "/")
 
 	if err := p.Recv(url, "GET", nil, &res); err != nil {
@@ -143,8 +151,8 @@ func (p *ProfileMgr) ListCustomProperties(prfID string) (*model.CustomProperties
 // RemoveCustomProperty
 func (p *ProfileMgr) RemoveCustomProperty(prfID, customKey string) error {
 	url := strings.Join([]string{
-		p.Endpoint,
-		urls.GenerateProfileURL(urls.Client, p.TenantId, prfID),
+		config.Endpoint,
+		urls.GenerateProfileURL(urls.Client, config.AuthOptions.GetTenantId(), prfID),
 		"customProperties", customKey}, "/")
 
 	return p.Recv(url, "DELETE", nil, nil)

--- a/client/profile.go
+++ b/client/profile.go
@@ -33,11 +33,10 @@ type ProfileBuilder *model.ProfileSpec
 type CustomBuilder *model.CustomPropertiesSpec
 
 // NewProfileMgr
-func NewProfileMgr(r Receiver, edp string, tenantId string) *ProfileMgr {
+func NewProfileMgr(r Receiver, edp string) *ProfileMgr {
 	return &ProfileMgr{
 		Receiver: r,
 		Endpoint: edp,
-		TenantId: tenantId,
 	}
 }
 
@@ -45,17 +44,12 @@ func NewProfileMgr(r Receiver, edp string, tenantId string) *ProfileMgr {
 type ProfileMgr struct {
 	Receiver
 	Endpoint string
-	TenantId string
 }
 
 // CreateProfile
 func (p *ProfileMgr) CreateProfile(body ProfileBuilder) (*model.ProfileSpec, error) {
 	var res model.ProfileSpec
-	url := strings.Join([]string{
-		p.Endpoint,
-		urls.GenerateProfileURL(urls.Client, p.TenantId)}, "/")
-
-	if err := p.Recv(url, "POST", body, &res); err != nil {
+	if err := p.Receiver.Recv(urls.ProfileResource, p.Endpoint, "POST", body, &res); err != nil {
 		return nil, err
 	}
 
@@ -65,11 +59,8 @@ func (p *ProfileMgr) CreateProfile(body ProfileBuilder) (*model.ProfileSpec, err
 // GetProfile
 func (p *ProfileMgr) GetProfile(prfID string) (*model.ProfileSpec, error) {
 	var res model.ProfileSpec
-	url := strings.Join([]string{
-		p.Endpoint,
-		urls.GenerateProfileURL(urls.Client, p.TenantId, prfID)}, "/")
 
-	if err := p.Recv(url, "GET", nil, &res); err != nil {
+	if err := p.Receiver.Recv(urls.ProfileResource, p.Endpoint, "GET", nil, &res, "", prfID); err != nil {
 		return nil, err
 	}
 
@@ -79,11 +70,8 @@ func (p *ProfileMgr) GetProfile(prfID string) (*model.ProfileSpec, error) {
 // UpdateProfile ...
 func (p *ProfileMgr) UpdateProfile(prfID string, body ProfileBuilder) (*model.ProfileSpec, error) {
 	var res model.ProfileSpec
-	url := strings.Join([]string{
-		p.Endpoint,
-		urls.GenerateProfileURL(urls.Client, p.TenantId, prfID)}, "/")
 
-	if err := p.Recv(url, "PUT", body, &res); err != nil {
+	if err := p.Receiver.Recv(urls.ProfileResource, p.Endpoint, "PUT", body, &res, "", prfID); err != nil {
 		return nil, err
 	}
 

--- a/client/replication.go
+++ b/client/replication.go
@@ -25,11 +25,10 @@ type ReplicationBuilder *model.ReplicationSpec
 type FailoverReplicationBuilder *model.FailoverReplicationSpec
 
 // NewReplicationMgr
-func NewReplicationMgr(r Receiver, edp string, tenantId string) *ReplicationMgr {
+func NewReplicationMgr(r Receiver, edp string) *ReplicationMgr {
 	return &ReplicationMgr{
 		Receiver: r,
 		Endpoint: edp,
-		TenantId: tenantId,
 	}
 }
 
@@ -37,7 +36,6 @@ func NewReplicationMgr(r Receiver, edp string, tenantId string) *ReplicationMgr 
 type ReplicationMgr struct {
 	Receiver
 	Endpoint string
-	TenantId string
 }
 
 // CreateReplication

--- a/client/replication.go
+++ b/client/replication.go
@@ -25,25 +25,23 @@ type ReplicationBuilder *model.ReplicationSpec
 type FailoverReplicationBuilder *model.FailoverReplicationSpec
 
 // NewReplicationMgr
-func NewReplicationMgr(r Receiver, edp string) *ReplicationMgr {
+func NewReplicationMgr(r Receiver) *ReplicationMgr {
 	return &ReplicationMgr{
 		Receiver: r,
-		Endpoint: edp,
 	}
 }
 
 // ReplicationMgr
 type ReplicationMgr struct {
 	Receiver
-	Endpoint string
 }
 
 // CreateReplication
 func (v *ReplicationMgr) CreateReplication(body ReplicationBuilder) (*model.ReplicationSpec, error) {
 	var res model.ReplicationSpec
 	url := strings.Join([]string{
-		v.Endpoint,
-		urls.GenerateReplicationURL(urls.Client, v.TenantId)}, "/")
+		config.Endpoint,
+		urls.GenerateReplicationURL(urls.Client, config.AuthOptions.GetTenantId())}, "/")
 
 	if err := v.Recv(url, "POST", body, &res); err != nil {
 		return nil, err
@@ -56,8 +54,8 @@ func (v *ReplicationMgr) CreateReplication(body ReplicationBuilder) (*model.Repl
 func (v *ReplicationMgr) GetReplication(replicaId string) (*model.ReplicationSpec, error) {
 	var res model.ReplicationSpec
 	url := strings.Join([]string{
-		v.Endpoint,
-		urls.GenerateReplicationURL(urls.Client, v.TenantId, replicaId)}, "/")
+		config.Endpoint,
+		urls.GenerateReplicationURL(urls.Client, config.AuthOptions.GetTenantId(), replicaId)}, "/")
 
 	if err := v.Recv(url, "GET", nil, &res); err != nil {
 		return nil, err
@@ -71,8 +69,8 @@ func (v *ReplicationMgr) ListReplications(args ...interface{}) ([]*model.Replica
 	var res []*model.ReplicationSpec
 
 	url := strings.Join([]string{
-		v.Endpoint,
-		urls.GenerateReplicationURL(urls.Client, v.TenantId, "detail")}, "/")
+		config.Endpoint,
+		urls.GenerateReplicationURL(urls.Client, config.AuthOptions.GetTenantId(), "detail")}, "/")
 
 	param, err := processListParam(args)
 	if err != nil {
@@ -93,8 +91,8 @@ func (v *ReplicationMgr) ListReplications(args ...interface{}) ([]*model.Replica
 // DeleteReplication
 func (v *ReplicationMgr) DeleteReplication(replicaId string, body ReplicationBuilder) error {
 	url := strings.Join([]string{
-		v.Endpoint,
-		urls.GenerateReplicationURL(urls.Client, v.TenantId, replicaId)}, "/")
+		config.Endpoint,
+		urls.GenerateReplicationURL(urls.Client, config.AuthOptions.GetTenantId(), replicaId)}, "/")
 	return v.Recv(url, "DELETE", body, nil)
 }
 
@@ -102,8 +100,8 @@ func (v *ReplicationMgr) DeleteReplication(replicaId string, body ReplicationBui
 func (v *ReplicationMgr) UpdateReplication(replicaId string, body ReplicationBuilder) (*model.ReplicationSpec, error) {
 	var res model.ReplicationSpec
 	url := strings.Join([]string{
-		v.Endpoint,
-		urls.GenerateReplicationURL(urls.Client, v.TenantId, replicaId)}, "/")
+		config.Endpoint,
+		urls.GenerateReplicationURL(urls.Client, config.AuthOptions.GetTenantId(), replicaId)}, "/")
 
 	if err := v.Recv(url, "PUT", body, &res); err != nil {
 		return nil, err
@@ -114,23 +112,23 @@ func (v *ReplicationMgr) UpdateReplication(replicaId string, body ReplicationBui
 // EnableReplication
 func (v *ReplicationMgr) EnableReplication(replicaId string) error {
 	url := strings.Join([]string{
-		v.Endpoint,
-		urls.GenerateReplicationURL(urls.Client, v.TenantId, replicaId, "enable")}, "/")
+		config.Endpoint,
+		urls.GenerateReplicationURL(urls.Client, config.AuthOptions.GetTenantId(), replicaId, "enable")}, "/")
 	return v.Recv(url, "POST", nil, nil)
 }
 
 // EnableReplication
 func (v *ReplicationMgr) DisableReplication(replicaId string) error {
 	url := strings.Join([]string{
-		v.Endpoint,
-		urls.GenerateReplicationURL(urls.Client, v.TenantId, replicaId, "disable")}, "/")
+		config.Endpoint,
+		urls.GenerateReplicationURL(urls.Client, config.AuthOptions.GetTenantId(), replicaId, "disable")}, "/")
 	return v.Recv(url, "POST", nil, nil)
 }
 
 // EnableReplication
 func (v *ReplicationMgr) FailoverReplication(replicaId string, body FailoverReplicationBuilder) error {
 	url := strings.Join([]string{
-		v.Endpoint,
-		urls.GenerateReplicationURL(urls.Client, v.TenantId, replicaId, "failover")}, "/")
+		config.Endpoint,
+		urls.GenerateReplicationURL(urls.Client, config.AuthOptions.GetTenantId(), replicaId, "failover")}, "/")
 	return v.Recv(url, "POST", body, nil)
 }

--- a/client/version.go
+++ b/client/version.go
@@ -26,7 +26,7 @@ import (
 type VersionBuilder *model.VersionSpec
 
 // NewVersionMgr ...
-func NewVersionMgr(r Receiver, edp string, tenantId string) *VersionMgr {
+func NewVersionMgr(r Receiver, edp string) *VersionMgr {
 	return &VersionMgr{
 		Receiver: r,
 		Endpoint: edp,
@@ -37,7 +37,6 @@ func NewVersionMgr(r Receiver, edp string, tenantId string) *VersionMgr {
 type VersionMgr struct {
 	Receiver
 	Endpoint string
-	tenantId string
 }
 
 // GetVersion ...

--- a/client/version.go
+++ b/client/version.go
@@ -26,24 +26,22 @@ import (
 type VersionBuilder *model.VersionSpec
 
 // NewVersionMgr ...
-func NewVersionMgr(r Receiver, edp string) *VersionMgr {
+func NewVersionMgr(r Receiver) *VersionMgr {
 	return &VersionMgr{
 		Receiver: r,
-		Endpoint: edp,
 	}
 }
 
 // VersionMgr ...
 type VersionMgr struct {
 	Receiver
-	Endpoint string
 }
 
 // GetVersion ...
 func (v *VersionMgr) GetVersion(apiVersion string) (*model.VersionSpec, error) {
 	var res model.VersionSpec
 	url := strings.Join([]string{
-		v.Endpoint, apiVersion}, "/")
+		config.Endpoint, apiVersion}, "/")
 
 	if err := v.Recv(url, "GET", nil, &res); err != nil {
 		return nil, err
@@ -55,7 +53,7 @@ func (v *VersionMgr) GetVersion(apiVersion string) (*model.VersionSpec, error) {
 // ListVersions ...
 func (v *VersionMgr) ListVersions() ([]*model.VersionSpec, error) {
 	var res []*model.VersionSpec
-	url := v.Endpoint
+	url := config.Endpoint
 
 	if err := v.Recv(url, "GET", nil, &res); err != nil {
 		return nil, err

--- a/client/volume.go
+++ b/client/volume.go
@@ -47,11 +47,10 @@ type VolumeSnapshotBuilder *model.VolumeSnapshotSpec
 type VolumeGroupBuilder *model.VolumeGroupSpec
 
 // NewVolumeMgr
-func NewVolumeMgr(r Receiver, edp string, tenantId string) *VolumeMgr {
+func NewVolumeMgr(r Receiver, edp string) *VolumeMgr {
 	return &VolumeMgr{
 		Receiver: r,
 		Endpoint: edp,
-		TenantId: tenantId,
 	}
 }
 
@@ -59,17 +58,12 @@ func NewVolumeMgr(r Receiver, edp string, tenantId string) *VolumeMgr {
 type VolumeMgr struct {
 	Receiver
 	Endpoint string
-	TenantId string
 }
 
 // CreateVolume
 func (v *VolumeMgr) CreateVolume(body VolumeBuilder) (*model.VolumeSpec, error) {
 	var res model.VolumeSpec
-	url := strings.Join([]string{
-		v.Endpoint,
-		urls.GenerateVolumeURL(urls.Client, v.TenantId)}, "/")
-
-	if err := v.Recv(url, "POST", body, &res); err != nil {
+	if err := v.Receiver.Recv(url.VolumeResource, v.Endpoint, "POST", body, &res); err != nil {
 		return nil, err
 	}
 
@@ -79,11 +73,7 @@ func (v *VolumeMgr) CreateVolume(body VolumeBuilder) (*model.VolumeSpec, error) 
 // GetVolume
 func (v *VolumeMgr) GetVolume(volID string) (*model.VolumeSpec, error) {
 	var res model.VolumeSpec
-	url := strings.Join([]string{
-		v.Endpoint,
-		urls.GenerateVolumeURL(urls.Client, v.TenantId, volID)}, "/")
-
-	if err := v.Recv(url, "GET", nil, &res); err != nil {
+	if err := v.Receiver.Recv(url.VolumeResource, v.EndPoint, "GET", body, &res, volID); err != nil {
 		return nil, err
 	}
 
@@ -92,10 +82,11 @@ func (v *VolumeMgr) GetVolume(volID string) (*model.VolumeSpec, error) {
 
 // ListVolumes
 func (v *VolumeMgr) ListVolumes(args ...interface{}) ([]*model.VolumeSpec, error) {
-	url := strings.Join([]string{
-		v.Endpoint,
-		urls.GenerateVolumeURL(urls.Client, v.TenantId)}, "/")
+	//	url := strings.Join([]string{
+	//		v.Endpoint,
+	//		urls.GenerateVolumeURL(urls.Client, v.TenantId)}, "/")
 
+	//	v.Receiver.Recv(url.VolumeResource, c.EndPoint, "POST", body, &res, volID)
 	param, err := processListParam(args)
 	if err != nil {
 		return nil, err
@@ -106,7 +97,8 @@ func (v *VolumeMgr) ListVolumes(args ...interface{}) ([]*model.VolumeSpec, error
 	}
 
 	var res []*model.VolumeSpec
-	if err := v.Recv(url, "GET", nil, &res); err != nil {
+
+	if err := v.Receiver.Recv(url.VolumeResource, v.EndPoint, "POST", body, &res, "?"+param); err != nil {
 		return nil, err
 	}
 	return res, nil
@@ -114,21 +106,14 @@ func (v *VolumeMgr) ListVolumes(args ...interface{}) ([]*model.VolumeSpec, error
 
 // DeleteVolume
 func (v *VolumeMgr) DeleteVolume(volID string, body VolumeBuilder) error {
-	url := strings.Join([]string{
-		v.Endpoint,
-		urls.GenerateVolumeURL(urls.Client, v.TenantId, volID)}, "/")
-
-	return v.Recv(url, "DELETE", body, nil)
+	return v.Receiver.Recv(url.VolumeResource, v.EndPoint, "DELETE", body, nil)
 }
 
 // UpdateVolume
 func (v *VolumeMgr) UpdateVolume(volID string, body VolumeBuilder) (*model.VolumeSpec, error) {
 	var res model.VolumeSpec
-	url := strings.Join([]string{
-		v.Endpoint,
-		urls.GenerateVolumeURL(urls.Client, v.TenantId, volID)}, "/")
 
-	if err := v.Recv(url, "PUT", body, &res); err != nil {
+	if err := v.Receiver.Recv(url.VolumeResource, v.EndPoint, "PUT", body, &res); err != nil {
 		return nil, err
 	}
 
@@ -138,11 +123,8 @@ func (v *VolumeMgr) UpdateVolume(volID string, body VolumeBuilder) (*model.Volum
 // ExtendVolume ...
 func (v *VolumeMgr) ExtendVolume(volID string, body ExtendVolumeBuilder) (*model.VolumeSpec, error) {
 	var res model.VolumeSpec
-	url := strings.Join([]string{
-		v.Endpoint,
-		urls.GenerateVolumeURL(urls.Client, v.TenantId, volID, "resize")}, "/")
 
-	if err := v.Recv(url, "POST", body, &res); err != nil {
+	if err := v.Receiver.Recv(url.VolumeResource, v.EndPoint, "POST", body, &res, volID, "resize"); err != nil {
 		return nil, err
 	}
 

--- a/osdsctl/cli/cli.go
+++ b/osdsctl/cli/cli.go
@@ -31,6 +31,7 @@ import (
 
 var (
 	client      *c.Client
+	config      *c.Config
 	rootCommand = &cobra.Command{
 		Use:   "osdsctl",
 		Short: "Administer the opensds storage cluster",

--- a/osdsctl/cli/dock_test.go
+++ b/osdsctl/cli/dock_test.go
@@ -23,7 +23,14 @@ import (
 )
 
 func init() {
-	client = c.NewFakeClient(&c.Config{Endpoint: c.TestEp})
+	client = c.NewFakeClient(
+		&c.Config{
+			Endpoint: c.TestEp,
+			AuthOptions: &c.KeystoneAuthOptions{
+				TenantID: "0105e3e4d44d40b59472688a3f28d469",
+				TokenID:  "MIIDcQYJKoZIhvcNAQcCoIIDYjCCA14CAQ",
+			},
+		})
 }
 
 func TestDockAction(t *testing.T) {

--- a/pkg/utils/urls/urls.go
+++ b/pkg/utils/urls/urls.go
@@ -21,57 +21,48 @@ import (
 )
 
 const (
-	Etcd                           = iota // Etcd == 0
-	Client                                // Client == 1
-	DockResource                   = "docks"
-	PoolResource                   = "pools"
-	ProfileResource                = "profiles"
-	VolumeResource                 = "block/volumes"
-	NewVolumeResource              = "volumes"
-	AttachmentResource             = "block/attachments"
-	SnapshotResource               = "block/snapshots"
-	ReplicationReplicationResource = "block/replications"
-	VolumeGroupResource            = "block/volumeGroups"
+	Etcd   = iota // Etcd == 0
+	Client        // Client == 1
 )
 
-//func GenerateDockURL(urlType int, tenantId string, in ...string) string {
-//	return GenerateURL("docks", urlType, tenantId, in...)
-//}
+func GenerateDockURL(urlType int, tenantId string, in ...string) string {
+	return generateURL("docks", urlType, tenantId, in...)
+}
 
-//func GeneratePoolURL(urlType int, tenantId string, in ...string) string {
-//	return GenerateURL("pools", urlType, tenantId, in...)
-//}
+func GeneratePoolURL(urlType int, tenantId string, in ...string) string {
+	return generateURL("pools", urlType, tenantId, in...)
+}
 
-//func GenerateProfileURL(urlType int, tenantId string, in ...string) string {
-//	return GenerateURL("profiles", urlType, tenantId, in...)
-//}
+func GenerateProfileURL(urlType int, tenantId string, in ...string) string {
+	return generateURL("profiles", urlType, tenantId, in...)
+}
 
-//func GenerateVolumeURL(urlType int, tenantId string, in ...string) string {
-//	return GenerateURL("block/volumes", urlType, tenantId, in...)
-//}
+func GenerateVolumeURL(urlType int, tenantId string, in ...string) string {
+	return generateURL("block/volumes", urlType, tenantId, in...)
+}
 
-//// GenerateNewVolumeURL ...
-//func GenerateNewVolumeURL(urlType int, tenantId string, in ...string) string {
-//	return GenerateURL("volumes", urlType, tenantId, in...)
-//}
+// GenerateNewVolumeURL ...
+func GenerateNewVolumeURL(urlType int, tenantId string, in ...string) string {
+	return generateURL("volumes", urlType, tenantId, in...)
+}
 
-//func GenerateAttachmentURL(urlType int, tenantId string, in ...string) string {
-//	return GenerateURL("block/attachments", urlType, tenantId, in...)
-//}
+func GenerateAttachmentURL(urlType int, tenantId string, in ...string) string {
+	return generateURL("block/attachments", urlType, tenantId, in...)
+}
 
-//func GenerateSnapshotURL(urlType int, tenantId string, in ...string) string {
-//	return GenerateURL("block/snapshots", urlType, tenantId, in...)
-//}
+func GenerateSnapshotURL(urlType int, tenantId string, in ...string) string {
+	return generateURL("block/snapshots", urlType, tenantId, in...)
+}
 
-//func GenerateReplicationURL(urlType int, tenantId string, in ...string) string {
-//	return GenerateURL("block/replications", urlType, tenantId, in...)
-//}
+func GenerateReplicationURL(urlType int, tenantId string, in ...string) string {
+	return generateURL("block/replications", urlType, tenantId, in...)
+}
 
-//func GenerateVolumeGroupURL(urlType int, tenantId string, in ...string) string {
-//	return GenerateURL("block/volumeGroups", urlType, tenantId, in...)
-//}
+func GenerateVolumeGroupURL(urlType int, tenantId string, in ...string) string {
+	return generateURL("block/volumeGroups", urlType, tenantId, in...)
+}
 
-func GenerateURL(resource string, urlType int, tenantId string, in ...string) string {
+func generateURL(resource string, urlType int, tenantId string, in ...string) string {
 	// If project id is not specified, ignore it.
 	if tenantId == "" {
 		value := []string{CurrentVersion(), resource}
@@ -93,4 +84,16 @@ func GenerateURL(resource string, urlType int, tenantId string, in ...string) st
 
 func CurrentVersion() string {
 	return constants.APIVersion
+}
+
+func ChangeURL(url, oldTenantId, newTenantId string) string {
+	u := strings.Split(url, "/")
+	for k, v := range u {
+		if v == oldTenantId {
+			u[k] = newTenantId
+			break
+		}
+	}
+
+	return strings.Join(u, "/")
 }

--- a/pkg/utils/urls/urls.go
+++ b/pkg/utils/urls/urls.go
@@ -21,48 +21,57 @@ import (
 )
 
 const (
-	Etcd   = iota // Etcd == 0
-	Client        // Client == 1
+	Etcd                           = iota // Etcd == 0
+	Client                                // Client == 1
+	DockResource                   = "docks"
+	PoolResource                   = "pools"
+	ProfileResource                = "profiles"
+	VolumeResource                 = "block/volumes"
+	NewVolumeResource              = "volumes"
+	AttachmentResource             = "block/attachments"
+	SnapshotResource               = "block/snapshots"
+	ReplicationReplicationResource = "block/replications"
+	VolumeGroupResource            = "block/volumeGroups"
 )
 
-func GenerateDockURL(urlType int, tenantId string, in ...string) string {
-	return generateURL("docks", urlType, tenantId, in...)
-}
+//func GenerateDockURL(urlType int, tenantId string, in ...string) string {
+//	return GenerateURL("docks", urlType, tenantId, in...)
+//}
 
-func GeneratePoolURL(urlType int, tenantId string, in ...string) string {
-	return generateURL("pools", urlType, tenantId, in...)
-}
+//func GeneratePoolURL(urlType int, tenantId string, in ...string) string {
+//	return GenerateURL("pools", urlType, tenantId, in...)
+//}
 
-func GenerateProfileURL(urlType int, tenantId string, in ...string) string {
-	return generateURL("profiles", urlType, tenantId, in...)
-}
+//func GenerateProfileURL(urlType int, tenantId string, in ...string) string {
+//	return GenerateURL("profiles", urlType, tenantId, in...)
+//}
 
-func GenerateVolumeURL(urlType int, tenantId string, in ...string) string {
-	return generateURL("block/volumes", urlType, tenantId, in...)
-}
+//func GenerateVolumeURL(urlType int, tenantId string, in ...string) string {
+//	return GenerateURL("block/volumes", urlType, tenantId, in...)
+//}
 
-// GenerateNewVolumeURL ...
-func GenerateNewVolumeURL(urlType int, tenantId string, in ...string) string {
-	return generateURL("volumes", urlType, tenantId, in...)
-}
+//// GenerateNewVolumeURL ...
+//func GenerateNewVolumeURL(urlType int, tenantId string, in ...string) string {
+//	return GenerateURL("volumes", urlType, tenantId, in...)
+//}
 
-func GenerateAttachmentURL(urlType int, tenantId string, in ...string) string {
-	return generateURL("block/attachments", urlType, tenantId, in...)
-}
+//func GenerateAttachmentURL(urlType int, tenantId string, in ...string) string {
+//	return GenerateURL("block/attachments", urlType, tenantId, in...)
+//}
 
-func GenerateSnapshotURL(urlType int, tenantId string, in ...string) string {
-	return generateURL("block/snapshots", urlType, tenantId, in...)
-}
+//func GenerateSnapshotURL(urlType int, tenantId string, in ...string) string {
+//	return GenerateURL("block/snapshots", urlType, tenantId, in...)
+//}
 
-func GenerateReplicationURL(urlType int, tenantId string, in ...string) string {
-	return generateURL("block/replications", urlType, tenantId, in...)
-}
+//func GenerateReplicationURL(urlType int, tenantId string, in ...string) string {
+//	return GenerateURL("block/replications", urlType, tenantId, in...)
+//}
 
-func GenerateVolumeGroupURL(urlType int, tenantId string, in ...string) string {
-	return generateURL("block/volumeGroups", urlType, tenantId, in...)
-}
+//func GenerateVolumeGroupURL(urlType int, tenantId string, in ...string) string {
+//	return GenerateURL("block/volumeGroups", urlType, tenantId, in...)
+//}
 
-func generateURL(resource string, urlType int, tenantId string, in ...string) string {
+func GenerateURL(resource string, urlType int, tenantId string, in ...string) string {
 	// If project id is not specified, ignore it.
 	if tenantId == "" {
 		value := []string{CurrentVersion(), resource}

--- a/pkg/utils/urls/urls_test.go
+++ b/pkg/utils/urls/urls_test.go
@@ -50,3 +50,29 @@ func TestGenerateURL(t *testing.T) {
 		t.Errorf("Expected %v, got %v\n", expected, url)
 	}
 }
+
+func TestChangeURL(t *testing.T) {
+	var org = "v1beta/docks/d3c7e0c7-6e92-406c-9767-3ab73b39b64f"
+	var expected = "v1beta/docks/0105e3e4d44d40b59472688a3f28d469"
+	if url := ChangeURL(org, "d3c7e0c7-6e92-406c-9767-3ab73b39b64f", "0105e3e4d44d40b59472688a3f28d469"); url != expected {
+		t.Errorf("Expected %v, got %v\n", expected, url)
+	}
+
+	org = "v1beta/pools/d3c7e0c7-6e92-406c-9767-3ab73b39b64f/8e5e92ca-d673-11e7-bca8-2ba95b86eb06"
+	expected = "v1beta/pools/0105e3e4d44d40b59472688a3f28d469/8e5e92ca-d673-11e7-bca8-2ba95b86eb06"
+	if url := ChangeURL(org, "d3c7e0c7-6e92-406c-9767-3ab73b39b64f", "0105e3e4d44d40b59472688a3f28d469"); url != expected {
+		t.Errorf("Expected %v, got %v\n", expected, url)
+	}
+
+	org = "v1beta/d3c7e0c7-6e92-406c-9767-3ab73b39b64f/docks"
+	expected = "v1beta/0105e3e4d44d40b59472688a3f28d469/docks"
+	if url := ChangeURL(org, "d3c7e0c7-6e92-406c-9767-3ab73b39b64f", "0105e3e4d44d40b59472688a3f28d469"); url != expected {
+		t.Errorf("Expected %v, got %v\n", expected, url)
+	}
+
+	org = "v1beta/d3c7e0c7-6e92-406c-9767-3ab73b39b64f/pools/8e5e92ca-d673-11e7-bca8-2ba95b86eb06"
+	expected = "v1beta/0105e3e4d44d40b59472688a3f28d469/pools/8e5e92ca-d673-11e7-bca8-2ba95b86eb06"
+	if url := ChangeURL(org, "d3c7e0c7-6e92-406c-9767-3ab73b39b64f", "0105e3e4d44d40b59472688a3f28d469"); url != expected {
+		t.Errorf("Expected %v, got %v\n", expected, url)
+	}
+}


### PR DESCRIPTION
…enantID in the url is not actually modified.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

URL contains tenant id. When StatusUnauthorized occurs, not only every token id and tenant id, but also every URL should be modified. I separate the `Config `from `Client `struct. so if unauthorized occurs, every token id, tenant id and URL will be updated.

**Which issue this PR fixes: fixes #584 