### PR TITLE
Set default GOPATH to golang's default

### DIFF
--- a/script/devsds/bootstrap.sh
+++ b/script/devsds/bootstrap.sh
@@ -52,12 +52,12 @@ source /etc/profile
 
 # if not found, install it.
 if [[ -z "$(which go)" ]]; then
-    log "Golang is not exist, downloading..."
+    log "Golang is not installed, downloading..."
     wget https://storage.googleapis.com/golang/${MINIMUM_GO_VERSION}.linux-amd64.tar.gz -O $OPT_DIR/${MINIMUM_GO_VERSION}.linux-amd64.tar.gz > /dev/null
     log "tar xzf $OPT_DIR/${MINIMUM_GO_VERSION}.linux-amd64.tar.gz -C /usr/local/"
     tar xzf $OPT_DIR/${MINIMUM_GO_VERSION}.linux-amd64.tar.gz -C /usr/local/
     echo 'export GOROOT=/usr/local/go' > $GOENV_PROFILE
-    echo 'export GOPATH=$HOME/gopath' >> $GOENV_PROFILE
+    echo 'export GOPATH=$HOME/go' >> $GOENV_PROFILE
     echo 'export PATH=$PATH:$GOROOT/bin:$GOPATH/bin' >> $GOENV_PROFILE
     source $GOENV_PROFILE
 fi
@@ -70,7 +70,7 @@ if [[ "${MINIMUM_GO_VERSION}" != $(echo -e "${MINIMUM_GO_VERSION}\n${go_version[
     exit 2
 fi
 
-GOPATH=${GOPATH:-$HOME/gopath}
+GOPATH=${GOPATH:-$HOME/go}
 OPENSDS_ROOT=${GOPATH}/src/github.com/opensds
 OPENSDS_DIR=${GOPATH}/src/github.com/opensds/opensds
 mkdir -p ${OPENSDS_ROOT}


### PR DESCRIPTION
**What this PR does / why we need it**:

The default GOPATH is '$HOME/go', but the bootstrap script was setting
it to '$HOME/gopath'. There shouldn't be a need to change this from the
language default location unless the user has already set their $GOPATH
environment variable to point to somewhere else, so this changes the
default to match.