### PR TITLE
bug: fix the umout issue

### DIFF
--- a/script/devsds/lib/lvm.sh
+++ b/script/devsds/lib/lvm.sh
@@ -216,7 +216,8 @@ osds::lvm::clean_nvme_volume_group(){
     ## umount nvme disk and remove corresponding dir
     for i in {1..10}
     do
-	sudo umount $NVME_DIR/$nvmevg
+	# 'umount -l' can umount even if target is busy
+	sudo umount -l $NVME_DIR/$nvmevg
 	if [ $? -eq 0 ]; then
 		sudo rmdir $NVME_DIR/$nvmevg
 		sudo rmdir $NVME_DIR


### PR DESCRIPTION
Sometimes the target is busy and could not be umounted, and so this
patch use 'umount -l' to umount the target.

Signed-off-by: Shixin Yang <shixin.yang@intel.com>
Signed-off-by: Qiaowei Ren <qiaowei.ren@intel.com>
