### PR TITLE
bug: fix the issue about target creation failure

### DIFF
--- a/contrib/drivers/lvm/targets/nvmeof.go
+++ b/contrib/drivers/lvm/targets/nvmeof.go
@@ -285,7 +285,9 @@ func (*NvmeoftgtTarget) WriteWithIo(name, content string) error {
 func (t *NvmeoftgtTarget) Getnamespaceid(volId string) string {
 	var buffer bytes.Buffer
 	for _, rune := range volId {
-		if rune >= '0' && rune <= '9' {
+		// nvme target namespace dir should not be like 00 or 0 ,
+		// so only digits range from 1 to 9 are accepted
+		if rune >= '1' && rune <= '9' {
 			buffer.WriteRune(rune)
 		}
 	}


### PR DESCRIPTION
The namespace dir should only contain digits and it can not be like 0 or 00,
so only digit from 1 to 9 are used.

Signed-off-by: Shixin Yang <shixin.yang@intel.com>
Signed-off-by: Qiaowei Ren <qiaowei.ren@intel.com>