### PR TITLE
Volume status error

### DIFF
--- a/pkg/api/db.go
+++ b/pkg/api/db.go
@@ -71,8 +71,6 @@ func CreateVolumeDBEntry(ctx *c.Context, in *model.VolumeSpec) (*model.VolumeSpe
 	in.Status = model.VolumeCreating
 	// Store the volume data into database.
 	return db.C.CreateVolume(ctx, in)
-	//result, err := db.C.CreateVolume(ctx, in)
-
 }
 
 func CreateVolumeError(ctx *c.Context, in *model.VolumeSpec) {
@@ -86,7 +84,6 @@ func CreateVolumeError(ctx *c.Context, in *model.VolumeSpec) {
 	}
 
 }
-
 // DeleteVolumeDBEntry just modifies the state of the volume to be deleting in
 // the DB, the real deletion operation would be executed in another new thread.
 func DeleteVolumeDBEntry(ctx *c.Context, in *model.VolumeSpec) error {
@@ -96,18 +93,6 @@ func DeleteVolumeDBEntry(ctx *c.Context, in *model.VolumeSpec) error {
 		errMsg := fmt.Sprintf("only the volume with the status available, error, error_deleting, error_extending can be deleted, the volume status is %s", in.Status)
 		log.Error(errMsg)
 		return errors.New(errMsg)
-	}
-
-	// If profileId or poolId of the volume doesn't exist, it would mean that
-	// the volume provisioning operation failed before the create method in
-	// storage driver was called, therefore the volume entry should be deleted
-	// from db directly.
-	if in.ProfileId == "" || in.PoolId == "" {
-		if err := db.C.DeleteVolume(ctx, in.Id); err != nil {
-			log.Error("when delete volume in db:", err)
-			return err
-		}
-		return nil
 	}
 
 	snaps, err := db.C.ListSnapshotsByVolumeId(ctx, in.Id)

--- a/pkg/api/db.go
+++ b/pkg/api/db.go
@@ -71,6 +71,20 @@ func CreateVolumeDBEntry(ctx *c.Context, in *model.VolumeSpec) (*model.VolumeSpe
 	in.Status = model.VolumeCreating
 	// Store the volume data into database.
 	return db.C.CreateVolume(ctx, in)
+	//result, err := db.C.CreateVolume(ctx, in)
+
+}
+
+func CreateVolumeError(ctx *c.Context, in *model.VolumeSpec) {
+	var errMsg = "Not able to connect to controller"
+	log.Error(errMsg)
+	in.UserId = ctx.UserId
+	in.Status = model.VolumeError
+	_, err := db.C.UpdateVolume(ctx, in)
+	if err != nil {
+		return
+	}
+
 }
 
 // DeleteVolumeDBEntry just modifies the state of the volume to be deleting in
@@ -82,6 +96,18 @@ func DeleteVolumeDBEntry(ctx *c.Context, in *model.VolumeSpec) error {
 		errMsg := fmt.Sprintf("only the volume with the status available, error, error_deleting, error_extending can be deleted, the volume status is %s", in.Status)
 		log.Error(errMsg)
 		return errors.New(errMsg)
+	}
+
+	// If profileId or poolId of the volume doesn't exist, it would mean that
+	// the volume provisioning operation failed before the create method in
+	// storage driver was called, therefore the volume entry should be deleted
+	// from db directly.
+	if in.ProfileId == "" || in.PoolId == "" {
+		if err := db.C.DeleteVolume(ctx, in.Id); err != nil {
+			log.Error("when delete volume in db:", err)
+			return err
+		}
+		return nil
 	}
 
 	snaps, err := db.C.ListSnapshotsByVolumeId(ctx, in.Id)

--- a/pkg/api/volume.go
+++ b/pkg/api/volume.go
@@ -61,12 +61,28 @@ func (v *VolumePortal) CreateVolume() {
 		v.ErrorHandle(model.ErrorBadRequest, errMsg)
 		return
 	}
+
+	// get profile
+	var prf *model.ProfileSpec
+	var err error
+	if volume.ProfileId == "" {
+		log.Warning("Use default profile when user doesn't specify profile.")
+		prf, err = db.C.GetDefaultProfile(ctx)
+		volume.ProfileId = prf.Id
+	} else {
+		prf, err = db.C.GetProfile(ctx, volume.ProfileId)
+	}
+	if err != nil {
+		errMsg := fmt.Sprintf("get profile failed: %s", err.Error())
+		v.ErrorHandle(model.ErrorBadRequest, errMsg)
+		return
+	}
+
 	// NOTE:It will create a volume entry into the database and initialize its status
 	// as "creating". It will not wait for the real volume creation to complete
 	// and will return result immediately.
 	result, err := CreateVolumeDBEntry(ctx, &volume)
 	if err != nil {
-
 		errMsg := fmt.Sprintf("create volume failed: %s", err.Error())
 		v.ErrorHandle(model.ErrorBadRequest, errMsg)
 		return
@@ -80,26 +96,20 @@ func (v *VolumePortal) CreateVolume() {
 	// Volume creation request is sent to the Dock. Dock will update volume status to "available"
 	// after volume creation is completed.
 	if err := v.CtrClient.Connect(CONF.OsdsLet.ApiEndpoint); err != nil {
-
 		log.Error("when connecting controller client:", err)
-		return
-	}
-
-	if err != nil {
-
-		errMsg := fmt.Sprintf("create volume failed: %s", err.Error())
-		v.ErrorHandle(model.ErrorBadRequest, errMsg)
 		return
 	}
 	defer v.CtrClient.Close()
 
 	opt := &pb.CreateVolumeOpts{
-		Id:                result.Id,
-		Name:              result.Name,
-		Description:       result.Description,
-		Size:              result.Size,
-		AvailabilityZone:  result.AvailabilityZone,
+		Id:               result.Id,
+		Name:             result.Name,
+		Description:      result.Description,
+		Size:             result.Size,
+		AvailabilityZone: result.AvailabilityZone,
+		// TODO: ProfileId will be removed later.
 		ProfileId:         result.ProfileId,
+		Profile:           prf.ToJson(),
 		PoolId:            result.PoolId,
 		SnapshotId:        result.SnapshotId,
 		Metadata:          result.Metadata,
@@ -258,6 +268,20 @@ func (v *VolumePortal) DeleteVolume() {
 		return
 	}
 
+	// If profileId or poolId of the volume doesn't exist, it would mean that
+	// the volume provisioning operation failed before the create method in
+	// storage driver was called, therefore the volume entry should be deleted
+	// from db directly.
+	if volume.ProfileId == "" || volume.PoolId == "" {
+		if err := db.C.DeleteVolume(ctx, volume.Id); err != nil {
+			errMsg := fmt.Sprintf("delete volume failed: %v", err.Error())
+			v.ErrorHandle(model.ErrorInternalServer, errMsg)
+			return
+		}
+		v.SuccessHandle(StatusAccepted, nil)
+		return
+	}
+
 	// NOTE:It will update the the status of the volume waiting for deletion in
 	// the database to "deleting" and return the result immediately.
 	if err = DeleteVolumeDBEntry(ctx, volume); err != nil {
@@ -265,6 +289,14 @@ func (v *VolumePortal) DeleteVolume() {
 		v.ErrorHandle(model.ErrorBadRequest, errMsg)
 		return
 	}
+
+	prf, err := db.C.GetProfile(ctx, volume.ProfileId)
+	if err != nil {
+		errMsg := fmt.Sprintf("delete volume failed: %v", err.Error())
+		v.ErrorHandle(model.ErrorInternalServer, errMsg)
+		return
+	}
+
 	v.SuccessHandle(StatusAccepted, nil)
 
 	// NOTE:The real volume deletion process.
@@ -282,6 +314,7 @@ func (v *VolumePortal) DeleteVolume() {
 		PoolId:    volume.PoolId,
 		Metadata:  volume.Metadata,
 		Context:   ctx.ToJson(),
+		Profile:   prf.ToJson(),
 	}
 	if _, err = v.CtrClient.DeleteVolume(context.Background(), opt); err != nil {
 		log.Error("delete volume failed in controller service:", err)

--- a/pkg/api/volume.go
+++ b/pkg/api/volume.go
@@ -61,28 +61,12 @@ func (v *VolumePortal) CreateVolume() {
 		v.ErrorHandle(model.ErrorBadRequest, errMsg)
 		return
 	}
-
-	// get profile
-	var prf *model.ProfileSpec
-	var err error
-	if volume.ProfileId == "" {
-		log.Warning("Use default profile when user doesn't specify profile.")
-		prf, err = db.C.GetDefaultProfile(ctx)
-		volume.ProfileId = prf.Id
-	} else {
-		prf, err = db.C.GetProfile(ctx, volume.ProfileId)
-	}
-	if err != nil {
-		errMsg := fmt.Sprintf("get profile failed: %s", err.Error())
-		v.ErrorHandle(model.ErrorBadRequest, errMsg)
-		return
-	}
-
 	// NOTE:It will create a volume entry into the database and initialize its status
 	// as "creating". It will not wait for the real volume creation to complete
 	// and will return result immediately.
 	result, err := CreateVolumeDBEntry(ctx, &volume)
 	if err != nil {
+
 		errMsg := fmt.Sprintf("create volume failed: %s", err.Error())
 		v.ErrorHandle(model.ErrorBadRequest, errMsg)
 		return
@@ -96,20 +80,26 @@ func (v *VolumePortal) CreateVolume() {
 	// Volume creation request is sent to the Dock. Dock will update volume status to "available"
 	// after volume creation is completed.
 	if err := v.CtrClient.Connect(CONF.OsdsLet.ApiEndpoint); err != nil {
+
 		log.Error("when connecting controller client:", err)
+		return
+	}
+
+	if err != nil {
+
+		errMsg := fmt.Sprintf("create volume failed: %s", err.Error())
+		v.ErrorHandle(model.ErrorBadRequest, errMsg)
 		return
 	}
 	defer v.CtrClient.Close()
 
 	opt := &pb.CreateVolumeOpts{
-		Id:               result.Id,
-		Name:             result.Name,
-		Description:      result.Description,
-		Size:             result.Size,
-		AvailabilityZone: result.AvailabilityZone,
-		// TODO: ProfileId will be removed later.
+		Id:                result.Id,
+		Name:              result.Name,
+		Description:       result.Description,
+		Size:              result.Size,
+		AvailabilityZone:  result.AvailabilityZone,
 		ProfileId:         result.ProfileId,
-		Profile:           prf.ToJson(),
 		PoolId:            result.PoolId,
 		SnapshotId:        result.SnapshotId,
 		Metadata:          result.Metadata,
@@ -117,7 +107,8 @@ func (v *VolumePortal) CreateVolume() {
 		Context:           ctx.ToJson(),
 	}
 	if _, err = v.CtrClient.CreateVolume(context.Background(), opt); err != nil {
-		log.Error("create volume failed in controller service:", err)
+		CreateVolumeError(ctx, &volume)
+		log.Error("create volume failed in API-server service:", err)
 		return
 	}
 
@@ -267,20 +258,6 @@ func (v *VolumePortal) DeleteVolume() {
 		return
 	}
 
-	// If profileId or poolId of the volume doesn't exist, it would mean that
-	// the volume provisioning operation failed before the create method in
-	// storage driver was called, therefore the volume entry should be deleted
-	// from db directly.
-	if volume.ProfileId == "" || volume.PoolId == "" {
-		if err := db.C.DeleteVolume(ctx, volume.Id); err != nil {
-			errMsg := fmt.Sprintf("delete volume failed: %v", err.Error())
-			v.ErrorHandle(model.ErrorInternalServer, errMsg)
-			return
-		}
-		v.SuccessHandle(StatusAccepted, nil)
-		return
-	}
-
 	// NOTE:It will update the the status of the volume waiting for deletion in
 	// the database to "deleting" and return the result immediately.
 	if err = DeleteVolumeDBEntry(ctx, volume); err != nil {
@@ -288,14 +265,6 @@ func (v *VolumePortal) DeleteVolume() {
 		v.ErrorHandle(model.ErrorBadRequest, errMsg)
 		return
 	}
-
-	prf, err := db.C.GetProfile(ctx, volume.ProfileId)
-	if err != nil {
-		errMsg := fmt.Sprintf("delete volume failed: %v", err.Error())
-		v.ErrorHandle(model.ErrorInternalServer, errMsg)
-		return
-	}
-
 	v.SuccessHandle(StatusAccepted, nil)
 
 	// NOTE:The real volume deletion process.
@@ -313,7 +282,6 @@ func (v *VolumePortal) DeleteVolume() {
 		PoolId:    volume.PoolId,
 		Metadata:  volume.Metadata,
 		Context:   ctx.ToJson(),
-		Profile:   prf.ToJson(),
 	}
 	if _, err = v.CtrClient.DeleteVolume(context.Background(), opt); err != nil {
 		log.Error("delete volume failed in controller service:", err)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #641` format, will close that issue when PR gets merged)*: fixes #

Is this a BUG REPORT or FEATURE REQUEST?:

/kind bug

What happened:
Currently when user creates a volume, api-server will create a volume object in database and update the status to creating, then controller will handler the rest and finally update the status to available or error based on the return value. But if some errors occur when apiserver connects controller, the operation would be abandoned and pull a error, but from user's view he can't find any problem and the status of volume would be set creating forever.

What you expected to happen:
Change volume status to error, rather than creating.


With this PR the status of Volume creation will become `error` if osdslet controller is not working. Earlier it was showing `creating` status ONLY.