### PR TITLE
Replace all golang.org/x/net/context with context

### DIFF
--- a/pkg/api/controllers/replication.go
+++ b/pkg/api/controllers/replication.go
@@ -15,6 +15,7 @@
 package controllers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -27,7 +28,6 @@ import (
 	"github.com/opensds/opensds/pkg/model"
 	pb "github.com/opensds/opensds/pkg/model/proto"
 	. "github.com/opensds/opensds/pkg/utils/config"
-	"golang.org/x/net/context"
 )
 
 func NewReplicationPortal() *ReplicationPortal {

--- a/pkg/api/controllers/volume.go
+++ b/pkg/api/controllers/volume.go
@@ -20,6 +20,7 @@ This module implements a entry into the OpenSDS northbound service.
 package controllers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -32,7 +33,6 @@ import (
 	"github.com/opensds/opensds/pkg/model"
 	pb "github.com/opensds/opensds/pkg/model/proto"
 	. "github.com/opensds/opensds/pkg/utils/config"
-	"golang.org/x/net/context"
 )
 
 func NewVolumePortal() *VolumePortal {

--- a/pkg/api/controllers/volumeGroup.go
+++ b/pkg/api/controllers/volumeGroup.go
@@ -15,6 +15,7 @@
 package controllers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -27,7 +28,6 @@ import (
 	"github.com/opensds/opensds/pkg/model"
 	pb "github.com/opensds/opensds/pkg/model/proto"
 	. "github.com/opensds/opensds/pkg/utils/config"
-	"golang.org/x/net/context"
 )
 
 func NewVolumeGroupPortal() *VolumeGroupPortal {

--- a/pkg/api/controllers/volume_test.go
+++ b/pkg/api/controllers/volume_test.go
@@ -16,6 +16,7 @@ package controllers
 
 import (
 	"bytes"
+	ctx "context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -31,7 +32,6 @@ import (
 	. "github.com/opensds/opensds/testutils/collection"
 	ctrtest "github.com/opensds/opensds/testutils/controller/testing"
 	dbtest "github.com/opensds/opensds/testutils/db/testing"
-	ctx "golang.org/x/net/context"
 )
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -19,6 +19,7 @@ This module implements a entry into the OpenSDS northbound service.
 package controller
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -34,7 +35,6 @@ import (
 	"github.com/opensds/opensds/pkg/model"
 	pb "github.com/opensds/opensds/pkg/model/proto"
 	"github.com/opensds/opensds/pkg/utils"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 )
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -15,7 +15,7 @@
 package controller
 
 import (
-	// "fmt"
+	"context"
 	"testing"
 
 	c "github.com/opensds/opensds/pkg/context"
@@ -26,7 +26,6 @@ import (
 	pb "github.com/opensds/opensds/pkg/model/proto"
 	. "github.com/opensds/opensds/testutils/collection"
 	dbtest "github.com/opensds/opensds/testutils/db/testing"
-	"golang.org/x/net/context"
 )
 
 type fakeSelector struct {

--- a/pkg/controller/policy/executor/executordeletesnapshot.go
+++ b/pkg/controller/policy/executor/executordeletesnapshot.go
@@ -21,6 +21,7 @@ profiles configured by admin.
 package executor
 
 import (
+	"context"
 	"encoding/json"
 	"time"
 
@@ -30,7 +31,6 @@ import (
 	"github.com/opensds/opensds/pkg/dock/client"
 	"github.com/opensds/opensds/pkg/model"
 	pb "github.com/opensds/opensds/pkg/model/proto"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/pkg/controller/policy/executor/executorintervalsnapshot.go
+++ b/pkg/controller/policy/executor/executorintervalsnapshot.go
@@ -21,6 +21,7 @@ profiles configured by admin.
 package executor
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"strconv"
@@ -31,7 +32,6 @@ import (
 	"github.com/opensds/opensds/pkg/dock/client"
 	"github.com/opensds/opensds/pkg/model"
 	pb "github.com/opensds/opensds/pkg/model/proto"
-	"golang.org/x/net/context"
 )
 
 type IntervalSnapshotExecutor struct {

--- a/pkg/controller/volume/volumecontroller.go
+++ b/pkg/controller/volume/volumecontroller.go
@@ -20,6 +20,7 @@ This module implements a entry into the OpenSDS volume controller service.
 package volume
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -28,7 +29,6 @@ import (
 	"github.com/opensds/opensds/pkg/dock/client"
 	"github.com/opensds/opensds/pkg/model"
 	pb "github.com/opensds/opensds/pkg/model/proto"
-	"golang.org/x/net/context"
 )
 
 // Controller is an interface for exposing some operations of different volume

--- a/pkg/controller/volume/volumecontroller_test.go
+++ b/pkg/controller/volume/volumecontroller_test.go
@@ -15,6 +15,7 @@
 package volume
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -22,7 +23,6 @@ import (
 	"github.com/opensds/opensds/pkg/model"
 	pb "github.com/opensds/opensds/pkg/model/proto"
 	. "github.com/opensds/opensds/testutils/collection"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 )
 

--- a/pkg/db/drivers/etcd/client.go
+++ b/pkg/db/drivers/etcd/client.go
@@ -15,13 +15,13 @@
 package etcd
 
 import (
+	"context"
 	"sync"
 	"time"
 
 	"github.com/coreos/etcd/clientv3"
 	log "github.com/golang/glog"
 	"github.com/opensds/opensds/pkg/utils"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/pkg/dock/dock.go
+++ b/pkg/dock/dock.go
@@ -19,6 +19,7 @@ This module implements the entry into operations of storageDock module.
 package dock
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -32,7 +33,6 @@ import (
 	"github.com/opensds/opensds/pkg/dock/discovery"
 	"github.com/opensds/opensds/pkg/model"
 	pb "github.com/opensds/opensds/pkg/model/proto"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
 	_ "github.com/opensds/opensds/contrib/connector/fc"


### PR DESCRIPTION
Signed-off-by: leonwanghui <wanghui71leon@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Since `context` is officially published in Go1.7+, this patch is proposed to replace `golang.org/x/net/context` package with official `context` package.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
