### PR TITLE
Fixed json marshal HTML escape error

### DIFF
--- a/osdsctl/cli/table.go
+++ b/osdsctl/cli/table.go
@@ -9,6 +9,7 @@
 package cli
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -38,8 +39,12 @@ type StructElemCb func(name string, value reflect.Value) error
 var m = bd{'-', '|', '+', '+', '+', '+', '+', '+', '+', '+', '+'}
 
 func JsonFormatter(v interface{}) string {
-	b, _ := json.MarshalIndent(v, "", " ")
-	return string(b)
+	buf := bytes.NewBuffer([]byte{})
+	enc := json.NewEncoder(buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", strings.Repeat(" ", 2))
+        enc.Encode(v)
+	return buf.String()
 }
 
 // Output formats slice of structs data and writes to standard output.(Using box drawing characters)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
json marshal will espace some problematic HTML characters in default mode, this is not need when showing on screen.  so close it.
befre :
``` bash
+--------------------------+--------------------------------------+
| Property                 | Value                                |
+--------------------------+--------------------------------------+
| Id                       | 68003f98-d77d-480c-9dd5-8a3c25499594 |
| CreatedAt                | 2019-05-06T15:16:26                  |
| UpdatedAt                |                                      |
| Name                     | test                                 |
| Description              |                                      |
| StorageType              |                                      |
| ProvisioningProperties   | {                                    |
|                          |  "dataStorage": {                    |
|                          |   "provisioningPolicy": "Thin",      |
|                          |   "isSpaceEfficient": false          |
|                          |  },                                  |
|                          |  "ioConnectivity": {                 |
|                          |   "accessProtocol": "iSCSI"          |
|                          |  }                                   |
|                          | }                                    |
| ReplicationProperties    | {                                    |
|                          |  "dataProtection": {                 |
|                          |   "isIsolated": false                |
|                          |  },                                  |
|                          |  "replicaInfos": {}                  |
|                          | }                                    |
| SnapshotProperties       | {                                    |
|                          |  "schedule": {},                     |
|                          |  "retention": {},                    |
|                          |  "topology": {}                      |
|                          | }                                    |
| DataProtectionProperties | {                                    |
|                          |  "dataProtection": {                 |
|                          |   "isIsolated": false                |
|                          |  }                                   |
|                          | }                                    |
| CustomProperties         | {                                    |
|                          |  "test1": "\u003cis\u003e true"      |
|                          | }                                    |
+--------------------------+--------------------------------------+
```
after:
```
+--------------------------+--------------------------------------+
| Property                 | Value                                |
+--------------------------+--------------------------------------+
| Id                       | 68003f98-d77d-480c-9dd5-8a3c25499594 |
| CreatedAt                | 2019-05-06T15:16:26                  |
| UpdatedAt                |                                      |
| Name                     | test                                 |
| Description              |                                      |
| StorageType              |                                      |
| ProvisioningProperties   | {                                    |
|                          |   "dataStorage": {                   |
|                          |     "provisioningPolicy": "Thin",    |
|                          |     "isSpaceEfficient": false        |
|                          |   },                                 |
|                          |   "ioConnectivity": {                |
|                          |     "accessProtocol": "iSCSI"        |
|                          |   }                                  |
|                          | }                                    |
|                          |                                      |
| ReplicationProperties    | {                                    |
|                          |   "dataProtection": {                |
|                          |     "isIsolated": false              |
|                          |   },                                 |
|                          |   "replicaInfos": {}                 |
|                          | }                                    |
|                          |                                      |
| SnapshotProperties       | {                                    |
|                          |   "schedule": {},                    |
|                          |   "retention": {},                   |
|                          |   "topology": {}                     |
|                          | }                                    |
|                          |                                      |
| DataProtectionProperties | {                                    |
|                          |   "dataProtection": {                |
|                          |     "isIsolated": false              |
|                          |   }                                  |
|                          | }                                    |
|                          |                                      |
| CustomProperties         | {                                    |
|                          |   "test1": "<is> true"               |
|                          | }                                    |
|                          |                                      |
+--------------------------+--------------------------------------+
```
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #713 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
