### PR TITLE
Shrink size of hotpot binary files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,16 +34,16 @@ prebuild:
 .PHONY: osdsdock osdslet osdsapiserver osdsctl docker test protoc
 
 osdsdock: prebuild
-	go build -o $(BUILD_DIR)/bin/osdsdock github.com/opensds/opensds/cmd/osdsdock
+	go build -ldflags '-w -s' -o $(BUILD_DIR)/bin/osdsdock github.com/opensds/opensds/cmd/osdsdock
 
 osdslet: prebuild
-	go build -o $(BUILD_DIR)/bin/osdslet github.com/opensds/opensds/cmd/osdslet
+	go build -ldflags '-w -s' -o $(BUILD_DIR)/bin/osdslet github.com/opensds/opensds/cmd/osdslet
 
 osdsapiserver: prebuild
-	go build -o $(BUILD_DIR)/bin/osdsapiserver github.com/opensds/opensds/cmd/osdsapiserver
+	go build -ldflags '-w -s' -o $(BUILD_DIR)/bin/osdsapiserver github.com/opensds/opensds/cmd/osdsapiserver
 
 osdsctl: prebuild
-	go build -o $(BUILD_DIR)/bin/osdsctl github.com/opensds/opensds/osdsctl
+	go build -ldflags '-w -s' -o $(BUILD_DIR)/bin/osdsctl github.com/opensds/opensds/osdsctl
 
 docker: build
 	cp $(BUILD_DIR)/bin/osdsdock ./cmd/osdsdock


### PR DESCRIPTION
Signed-off-by: leonwanghui <wanghui71leon@gmail.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Currently it's too large for the size of hotpot built binary files, see below:
```shell
root@***:~/workspace/gopath/src/github.com/opensds/opensds# ls -lht build/out/bin/
total 78M
-rwxr-xr-x 1 root root 15M May  9 16:18 osdsctl
-rwxr-xr-x 1 root root 23M May  9 16:18 osdsapiserver
-rwxr-xr-x 1 root root 20M May  9 16:18 osdslet
-rwxr-xr-x 1 root root 22M May  9 16:18 osdsdock
```

But with `-ldflags '-w -s'` flag, we can shrink them a lot (see below):
```shell
root@***:~/workspace/gopath/src/github.com/opensds/opensds# ls -lht build/out/bin/
total 57M
-rwxr-xr-x 1 root root 11M May 10 03:59 osdsctl
-rwxr-xr-x 1 root root 17M May 10 03:59 osdsapiserver
-rwxr-xr-x 1 root root 14M May 10 03:59 osdslet
-rwxr-xr-x 1 root root 16M May 10 03:59 osdsdock
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
