### PR TITLE
Fix osdsdock Discover method

### DIFF
--- a/pkg/dock/discovery/discovery.go
+++ b/pkg/dock/discovery/discovery.go
@@ -139,13 +139,17 @@ func (pdd *provisionDockDiscoverer) Discover() error {
 	for _, dck := range pdd.dcks {
 		// Call function of StorageDrivers configured by storage drivers.
 		if utils.Contains(filesharedrivers, dck.DriverName) {
-			pols, err = fd.Init(dck.DriverName).ListPools()
+			d := fd.Init(dck.DriverName)
+			defer fd.Clean(d)
+			pols, err = d.ListPools()
 			for _, pol := range pols {
 				log.Infof("Backend %s discovered pool %s", dck.DriverName, pol.Name)
 				pol.DockId = dck.Id
 			}
 		} else {
-			pols, err = drivers.Init(dck.DriverName).ListPools()
+			d := drivers.Init(dck.DriverName)
+			defer drivers.Clean(d)
+			pols, err = d.ListPools()
 
 			replicationDriverName := dck.Metadata["HostReplicationDriver"]
 			replicationType := model.ReplicationTypeHost


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR fix the issue. (#760)
Discover method in osdsdock call Clean method for storage drivers

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #760

**Special notes for your reviewer**:
In my environment I can resolve the issue by this fix.
Please take a look. Thanks.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
