### PR TITLE
Updated logic to handle metrics labels for NodeExporter and PushGateway

### DIFF
--- a/cmd/osdslet/osdslet.go
+++ b/cmd/osdslet/osdslet.go
@@ -40,6 +40,8 @@ func init() {
 	flag.DurationVar(&CONF.OsdsLet.LogFlushFrequency, "log-flush-frequency", CONF.OsdsLet.LogFlushFrequency, "Maximum number of seconds between log flushes")
 
 	flag.StringVar(&CONF.OsdsLet.PrometheusPushMechanism, "prometheus-push-mechanism", CONF.OsdsLet.PrometheusPushMechanism, "Prometheus push mechanism")
+	flag.StringVar(&CONF.OsdsLet.PushGatewayUrl, "prometheus-push-gateway-url", CONF.OsdsLet.PushGatewayUrl, "Prometheus push gateway URL")
+	flag.StringVar(&CONF.OsdsLet.NodeExporterWatchFolder, "node-exporter-watch-folder", CONF.OsdsLet.NodeExporterWatchFolder, "Node exporter watch folder")
 
 	flag.Parse()
 

--- a/pkg/utils/config/config_define.go
+++ b/pkg/utils/config/config_define.go
@@ -51,6 +51,8 @@ type OsdsLet struct {
 	LogFlushFrequency time.Duration `conf:"log_flush_frequency,5s"` // Default value is 5s
 	// how to push metrics to Prometheus ? options are PushGateway or NodeExporter
 	PrometheusPushMechanism string `conf:"prometheus_push_mechanism,NodeExporter"`
+	PushGatewayUrl          string `conf:"prometheus_push_gateway_url,http://localhost:9091"`
+	NodeExporterWatchFolder string `conf:"node_exporter_watch_folder,/root/prom_nodeexporter_folder/"`
 }
 
 type OsdsDock struct {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR aligns the labels when we export data to Prometheus, either by using the Push gateway or the Node Exporter

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
fixes #750 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
