### PR TITLE
Add authorization support for Telemetry APIs

### DIFF
--- a/examples/policy.json
+++ b/examples/policy.json
@@ -46,5 +46,10 @@
   "volume_group:get": "rule:admin_or_owner",
   "volume_group:update": "rule:admin_or_owner",
   "volume_group:delete": "rule:admin_or_owner",
-  "availability_zone:list":""
+  "availability_zone:list":"",
+  "metrics:get": "rule:admin_or_owner",
+  "metrics:collect": "rule:admin_or_owner",
+  "metrics:uploadconf": "rule:admin_api",
+  "metrics:downloadconf": "rule:admin_api",
+  "metrics:urls": "rule:admin_or_owner"
 }

--- a/pkg/api/controllers/metrics.go
+++ b/pkg/api/controllers/metrics.go
@@ -127,6 +127,9 @@ func (m *MetricsPortal) GetMetrics() {
 
 func (m *MetricsPortal) UploadConfFile() {
 
+	if !policy.Authorize(m.Ctx, "metrics:uploadconf") {
+		return
+	}
 	params, _ := m.GetParameters()
 	confType := params["conftype"][0]
 
@@ -211,6 +214,9 @@ func DoUpload(metricsPortal *MetricsPortal, confHome string, url string, reloadP
 
 func (m *MetricsPortal) DownloadConfFile() {
 
+	if !policy.Authorize(m.Ctx, "metrics:downloadconf") {
+		return
+	}
 	params, _ := m.GetParameters()
 	confType := params["conftype"][0]
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This adds support for the Telemetry APIs to be authorized.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
The authorization level for each API is given in the release note section. This will be tested with the UI integration (which will be done in a day or so).

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
"metrics:get": "rule:admin_or_owner",
  "metrics:collect": "rule:admin_or_owner",
  "metrics:uploadconf": "rule:admin_api",
  "metrics:downloadconf": "rule:admin_api",
  "metrics:urls": "rule:admin_or_owner"```
```
