### PR TITLE
Adding profile to CreateFileShareAcl and snapshot issue

### DIFF
--- a/contrib/drivers/filesharedrivers/drivers.go
+++ b/contrib/drivers/filesharedrivers/drivers.go
@@ -38,6 +38,8 @@ type FileShareDriver interface {
 
 	CreateFileShareAcl(opt *pb.CreateFileShareAclOpts) (*model.FileShareAclSpec, error)
 
+	DeleteFileShareAcl(opt *pb.DeleteFileShareAclOpts) (*model.FileShareAclSpec, error)
+
 	ListPools() ([]*model.StoragePoolSpec, error)
 
 	DeleteFileShare(opts *pb.DeleteFileShareOpts) (*model.FileShareSpec, error)

--- a/contrib/drivers/filesharedrivers/nfs/cli.go
+++ b/contrib/drivers/filesharedrivers/nfs/cli.go
@@ -75,6 +75,21 @@ func (c *Cli) CreateAccess(accessto, accesscapability, fname string) error {
 	return err
 }
 
+func (c *Cli) DeleteAccess(accessto, fname string) error {
+	var accesstoAndMount string
+	sharePath := path.Join("var/", fname)
+	accesstoAndMount = fmt.Sprintf("%s:/%s", accessto, strings.Replace(sharePath, "-", "_", -1))
+	cmd := []string{
+		"env", "LC_ALL=C",
+		"exportfs",
+		"-u",
+		accesstoAndMount,
+	}
+	_, err := c.execute(cmd...)
+
+	return err
+}
+
 func (c *Cli) UnMount(dirName string) error {
 	cmd := []string{
 		"env", "LC_ALL=C",

--- a/contrib/drivers/filesharedrivers/nfs/cli.go
+++ b/contrib/drivers/filesharedrivers/nfs/cli.go
@@ -106,6 +106,16 @@ func (c *Cli) CreateDirectory(dirName string) error {
 	return err
 }
 
+func (c *Cli) DeleteDirectory(dirName string) error {
+	cmd := []string{
+		"env", "LC_ALL=C",
+		"rm", "-rf",
+		dirName,
+	}
+	_, err := c.execute(cmd...)
+	return err
+}
+
 func (c *Cli) SetPermission(dirName string) error {
 	cmd := []string{
 		"env", "LC_ALL=C",

--- a/contrib/drivers/filesharedrivers/nfs/nfs.go
+++ b/contrib/drivers/filesharedrivers/nfs/nfs.go
@@ -41,12 +41,14 @@ const (
 )
 
 const (
-	KLvPath        = "lvPath"
-	KLvsPath       = "lvsPath"
-	KFileshareName = "nfsFileshareName"
-	KFileshareID   = "nfsFileshareID"
-	AccessLevelRo  = "ro"
-	AccessLevelRw  = "rw"
+	KLvPath            = "lvPath"
+	KLvsPath           = "lvsPath"
+	KFileshareName     = "nfsFileshareName"
+	KFileshareID       = "nfsFileshareID"
+	KFileshareSnapName = "snapshotName"
+	KFileshareSnapID   = "snapshotID"
+	AccessLevelRo      = "ro"
+	AccessLevelRw      = "rw"
 )
 
 type NFSConfig struct {
@@ -233,7 +235,11 @@ func (d *Driver) DeleteFileShare(opt *pb.DeleteFileShareOpts) (fshare *model.Fil
 		log.Error("failed to remove logic volume:", err)
 		return fshare, err
 	}
-
+	// Delete the directory
+	if err := d.cli.DeleteDirectory(dirName); err != nil {
+		log.Error("failed to delete the directory:", err)
+		return nil, err
+	}
 	return fshare, nil
 }
 
@@ -246,7 +252,6 @@ func (d *Driver) CreateFileShareSnapshot(opt *pb.CreateFileShareSnapshotOpts) (*
 		return nil, err
 	}
 	snapName := opt.GetName()
-
 	fields := strings.Split(lvPath, "/")
 
 	vg, sourceLvName := fields[2], fields[3]
@@ -263,9 +268,9 @@ func (d *Driver) CreateFileShareSnapshot(opt *pb.CreateFileShareSnapshotOpts) (*
 		SnapshotSize: opt.GetSize(),
 		Description:  opt.GetDescription(),
 		Metadata: map[string]string{
-			KFileshareName: snapName,
-			KFileshareID:   opt.GetId(),
-			KLvPath:        lvPath,
+			KFileshareSnapName: snapName,
+			KFileshareSnapID:   opt.GetId(),
+			KLvPath:            lvPath,
 		},
 	}, nil
 }
@@ -273,13 +278,14 @@ func (d *Driver) CreateFileShareSnapshot(opt *pb.CreateFileShareSnapshotOpts) (*
 // DeleteFileShareSnapshot
 func (d *Driver) DeleteFileShareSnapshot(opt *pb.DeleteFileShareSnapshotOpts) (*model.FileShareSnapshotSpec, error) {
 	lvsPath, ok := opt.GetMetadata()[KLvPath]
+	snapName := opt.GetMetadata()[KFileshareSnapName]
 	if !ok {
 		err := errors.New("can't find 'lvsPath' in snapshot metadata, ingnore it!")
 		log.Error(err)
 		return nil, nil
 	}
 	fields := strings.Split(lvsPath, "/")
-	vg, snapName := fields[2], fields[3]
+	vg := fields[2]
 	if !d.cli.Exists(snapName) {
 		log.Warningf("Snapshot(%s) does not exist, nothing to remove", snapName)
 		return nil, nil

--- a/contrib/drivers/filesharedrivers/nfs/nfs.go
+++ b/contrib/drivers/filesharedrivers/nfs/nfs.go
@@ -93,7 +93,7 @@ func (d *Driver) CreateFileShareAcl(opt *pb.CreateFileShareAclOpts) (fshare *mod
 	// get accessCapability list
 	accessCapability = opt.GetAccessCapability()
 	// get fileshare name
-	fname := opt.GetName()
+	fname := opt.GetMetadata()[KFileshareName]
 
 	for _, value := range accessCapability {
 		if value == "w" {
@@ -106,6 +106,19 @@ func (d *Driver) CreateFileShareAcl(opt *pb.CreateFileShareAclOpts) (fshare *mod
 
 	for _, server := range accessTo {
 		err = d.cli.CreateAccess(server, access, fname)
+	}
+	return fshare, nil
+}
+
+func (d *Driver) DeleteFileShareAcl(opt *pb.DeleteFileShareAclOpts) (fshare *model.FileShareAclSpec, err error) {
+	var accessTo []string
+	// Get accessto list
+	accessTo = opt.GetAccessTo()
+	// get fileshare name
+	fname := opt.GetMetadata()[KFileshareName]
+
+	for _, server := range accessTo {
+		err = d.cli.DeleteAccess(server, fname)
 	}
 	return fshare, nil
 }

--- a/pkg/api/controllers/fileshare.go
+++ b/pkg/api/controllers/fileshare.go
@@ -44,6 +44,8 @@ type FileSharePortal struct {
 // Function to store Acl's related entry into databse
 func (f *FileSharePortal) CreateFileShareAcl() {
 	ctx := c.GetContext(f.Ctx)
+	// Get profile
+	var prf *model.ProfileSpec
 	var fileshareacl = model.FileShareAclSpec{
 		BaseModel: &model.BaseModel{},
 	}
@@ -88,6 +90,7 @@ func (f *FileSharePortal) CreateFileShareAcl() {
 		AccessCapability: result.AccessCapability,
 		AccessTo:         result.AccessTo,
 		Context:          ctx.ToJson(),
+		Profile:          prf.ToJson(),
 	}
 
 	if _, err = f.CtrClient.CreateFileShareAcl(context.Background(), opt); err != nil {
@@ -581,6 +584,7 @@ func (f *FileShareSnapshotPortal) DeleteFileShareSnapshot() {
 		FileshareId: snapshot.FileShareId,
 		Context:     ctx.ToJson(),
 		Profile:     prf.ToJson(),
+		Metadata:    snapshot.Metadata,
 	}
 	if _, err = f.CtrClient.DeleteFileShareSnapshot(context.Background(), opt); err != nil {
 		log.Error("delete file share snapshot failed in controller service:", err)

--- a/pkg/api/controllers/fileshare.go
+++ b/pkg/api/controllers/fileshare.go
@@ -57,11 +57,23 @@ func (f *FileSharePortal) CreateFileShareAcl() {
 		return
 	}
 	result, err := util.CreateFileShareAclDBEntry(c.GetContext(f.Ctx), &fileshareacl)
-
 	if err != nil {
-		reason := fmt.Sprintf("create access rules for fileshare failed: %s", err.Error())
+		reason := fmt.Sprintf("createFileshareAcldbentry failed: %s", err.Error())
 		f.ErrorHandle(model.ErrorBadRequest, reason)
 		log.Error(reason)
+		return
+	}
+	fileshare, err := db.C.GetFileShare(ctx, result.FileShareId)
+	if err != nil {
+		reason := fmt.Sprintf("getFileshare failed in createfileshare acl: %s", err.Error())
+		f.ErrorHandle(model.ErrorBadRequest, reason)
+		log.Error(reason)
+		return
+	}
+	prf, err = db.C.GetProfile(ctx, fileshare.ProfileId)
+	if err != nil {
+		errMsg := fmt.Sprintf("get profile failed: %s", err.Error())
+		f.ErrorHandle(model.ErrorBadRequest, errMsg)
 		return
 	}
 	// Marshal the result.
@@ -72,7 +84,6 @@ func (f *FileSharePortal) CreateFileShareAcl() {
 		log.Error(reason)
 		return
 	}
-
 	f.SuccessHandle(StatusAccepted, body)
 
 	// FileShare acl access creation request is sent to dock and drivers
@@ -89,6 +100,7 @@ func (f *FileSharePortal) CreateFileShareAcl() {
 		Type:             result.Type,
 		AccessCapability: result.AccessCapability,
 		AccessTo:         result.AccessTo,
+		Metadata:         fileshare.Metadata,
 		Context:          ctx.ToJson(),
 		Profile:          prf.ToJson(),
 	}
@@ -303,6 +315,9 @@ func (f *FileSharePortal) UpdateFileShare() {
 }
 
 func (f *FileSharePortal) DeleteFileShareAcl() {
+	// Get profile
+	var prf *model.ProfileSpec
+
 	ctx := c.GetContext(f.Ctx)
 
 	var err error
@@ -314,12 +329,48 @@ func (f *FileSharePortal) DeleteFileShareAcl() {
 		return
 	}
 
+	fileshare, err := db.C.GetFileShare(ctx, acl.FileShareId)
+	if err != nil {
+		errMsg := fmt.Sprintf("fileshare for the acl %s not found: %s", id, err.Error())
+		f.ErrorHandle(model.ErrorNotFound, errMsg)
+		return
+	}
+
+	prf, err = db.C.GetProfile(ctx, fileshare.ProfileId)
+	if err != nil {
+		errMsg := fmt.Sprintf("get profile failed: %s", err.Error())
+		f.ErrorHandle(model.ErrorBadRequest, errMsg)
+		return
+	}
+
 	if err := db.C.DeleteFileShareAcl(ctx, acl.Id); err != nil {
 		errMsg := fmt.Sprintf("delete fileshare acl failed: %v", err.Error())
 		f.ErrorHandle(model.ErrorInternalServer, errMsg)
 		return
 	}
 	f.SuccessHandle(StatusAccepted, nil)
+	// NOTE: The real file share deletion process.
+	// File Share deletion request is sent to the Dock. Dock will delete file share from driver
+	// and database or update file share status to "errorDeleting" if deletion from driver failed.
+	if err := f.CtrClient.Connect(CONF.OsdsLet.ApiEndpoint); err != nil {
+		log.Error("when connecting controller client:", err)
+		return
+	}
+	defer f.CtrClient.Close()
+	opt := &pb.DeleteFileShareAclOpts{
+		FileShareId:      acl.FileShareId,
+		Description:      acl.Description,
+		Type:             acl.Type,
+		AccessCapability: acl.AccessCapability,
+		AccessTo:         acl.AccessTo,
+		Metadata:         fileshare.Metadata,
+		Context:          ctx.ToJson(),
+		Profile:          prf.ToJson(),
+	}
+	if _, err = f.CtrClient.DeleteFileShareAcl(context.Background(), opt); err != nil {
+		log.Error("delete fileshare failed in controller service:", err)
+		return
+	}
 	return
 }
 

--- a/pkg/api/util/db.go
+++ b/pkg/api/util/db.go
@@ -132,6 +132,7 @@ func CreateFileShareSnapshotDBEntry(ctx *c.Context, in *model.FileShareSnapshotS
 	}
 
 	in.Status = model.FileShareSnapCreating
+	in.Metadata = fshare.Metadata
 	return db.C.CreateFileShareSnapshot(ctx, in)
 }
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1019,8 +1019,6 @@ func (c *Controller) CreateFileShareSnapshot(contx context.Context, opt *pb.Crea
 		return pb.GenericResponseError(err), err
 	}
 	opt.Size = fileshare.Size
-	opt.Metadata = utils.MergeStringMaps(opt.Metadata, fileshare.Metadata)
-
 	dockInfo, err := db.C.GetDockByPoolId(ctx, fileshare.PoolId)
 	if err != nil {
 		log.Error("when search supported dock resource: ", err)

--- a/pkg/controller/fileshare/filesharecontroller.go
+++ b/pkg/controller/fileshare/filesharecontroller.go
@@ -39,6 +39,8 @@ type Controller interface {
 
 	CreateFileShareAcl(opt *pb.CreateFileShareAclOpts) (*model.FileShareAclSpec, error)
 
+	DeleteFileShareAcl(opt *pb.DeleteFileShareAclOpts) (*model.FileShareAclSpec, error)
+
 	DeleteFileShare(opt *pb.DeleteFileShareOpts) error
 
 	CreateFileShareSnapshot(opt *pb.CreateFileShareSnapshotOpts) (*model.FileShareSnapshotSpec, error)
@@ -85,6 +87,34 @@ func (c *controller) CreateFileShareAcl(opt *pb.CreateFileShareAclOpts) (*model.
 
 	return fileshare, nil
 
+}
+
+func (c *controller) DeleteFileShareAcl(opt *pb.DeleteFileShareAclOpts) (*model.FileShareAclSpec, error) {
+	if err := c.Client.Connect(c.DockInfo.Endpoint); err != nil {
+		log.Error("when connecting dock client:", err)
+		return nil, err
+	}
+
+	response, err := c.Client.DeleteFileShareAcl(context.Background(), opt)
+	if err != nil {
+		log.Error("delete file share acl failed in file share controller:", err)
+		return nil, err
+	}
+	defer c.Client.Close()
+
+	if errorMsg := response.GetError(); errorMsg != nil {
+		return nil,
+			fmt.Errorf("failed to delete file share acl in file share controller, code: %v, message: %v",
+				errorMsg.GetCode(), errorMsg.GetDescription())
+	}
+
+	var fileshare = &model.FileShareAclSpec{}
+	if err = json.Unmarshal([]byte(response.GetResult().GetMessage()), fileshare); err != nil {
+		log.Error("delete file share acl failed in file share controller:", err)
+		return nil, err
+	}
+
+	return fileshare, nil
 }
 
 func (c *controller) CreateFileShare(opt *pb.CreateFileShareOpts) (*model.FileShareSpec, error) {

--- a/pkg/controller/fileshare/filesharecontroller_test.go
+++ b/pkg/controller/fileshare/filesharecontroller_test.go
@@ -71,6 +71,17 @@ func (fc *fakefileshareClient) DeleteFileShare(ctx context.Context, in *pb.Delet
 	}, nil
 }
 
+// DeleteFileShareAcl provides a mock function with given fields: ctx, in, opts
+func (fc *fakefileshareClient) DeleteFileShareAcl(ctx context.Context, in *pb.DeleteFileShareAclOpts, opts ...grpc.CallOption) (*pb.GenericResponse, error) {
+	return &pb.GenericResponse{
+		Reply: &pb.GenericResponse_Result_{
+			Result: &pb.GenericResponse_Result{
+				Message: ByteFileShareAcl,
+			},
+		},
+	}, nil
+}
+
 func (fc *fakefileshareClient) CreateFileShareSnapshot(ctx context.Context, in *pb.CreateFileShareSnapshotOpts, opts ...grpc.CallOption) (*pb.GenericResponse, error) {
 	return &pb.GenericResponse{
 		Reply: &pb.GenericResponse_Result_{

--- a/pkg/controller/volume/volumecontroller_test.go
+++ b/pkg/controller/volume/volumecontroller_test.go
@@ -355,6 +355,10 @@ func (fc *fakeClient) CreateFileShareAcl(ctx context.Context, in *pb.CreateFileS
 	return nil, nil
 }
 
+func (fc *fakeClient) DeleteFileShareAcl(ctx context.Context, in *pb.DeleteFileShareAclOpts, opts ...grpc.CallOption) (*pb.GenericResponse, error) {
+	return nil, nil
+}
+
 // DeleteFileShare provides a mock function with given fields: ctx, in, opts
 func (fc *fakeClient) DeleteFileShare(ctx context.Context, in *pb.DeleteFileShareOpts, opts ...grpc.CallOption) (*pb.GenericResponse, error) {
 	return nil, nil

--- a/pkg/db/drivers/etcd/etcd.go
+++ b/pkg/db/drivers/etcd/etcd.go
@@ -795,6 +795,8 @@ func (c *Client) UpdateFileShareSnapshot(ctx *c.Context, snpID string, snp *mode
 	// Set update time
 	result.UpdatedAt = time.Now().Format(constants.TimeFormat)
 
+	result.Metadata = snp.Metadata
+
 	atcBody, err := json.Marshal(result)
 	if err != nil {
 		return nil, err
@@ -809,7 +811,6 @@ func (c *Client) UpdateFileShareSnapshot(ctx *c.Context, snpID string, snp *mode
 		Url:        urls.GenerateFileShareSnapshotURL(urls.Etcd, result.TenantId, snpID),
 		NewContent: string(atcBody),
 	}
-
 	dbRes := c.Update(dbReq)
 	if dbRes.Status != "Success" {
 		log.Error("when update fileshare snapshot in db:", dbRes.Error)
@@ -2925,6 +2926,14 @@ func (c *Client) UpdateStatus(ctx *c.Context, in interface{}, status string) err
 		fileshare := in.(*model.FileShareSpec)
 		fileshare.Status = status
 		if _, errUpdate := c.UpdateFileShare(ctx, fileshare); errUpdate != nil {
+			log.Error("when update fileshare status in db:", errUpdate.Error())
+			return errUpdate
+		}
+
+	case *model.FileShareSnapshotSpec:
+		fsnap := in.(*model.FileShareSnapshotSpec)
+		fsnap.Status = status
+		if _, errUpdate := c.UpdateFileShareSnapshot(ctx, fsnap.Id, fsnap); errUpdate != nil {
 			log.Error("when update fileshare status in db:", errUpdate.Error())
 			return errUpdate
 		}

--- a/pkg/dock/dock.go
+++ b/pkg/dock/dock.go
@@ -504,6 +504,23 @@ func (ds *dockServer) CreateFileShareAcl(ctx context.Context, opt *pb.CreateFile
 	return pb.GenericResponseResult(fileshare), nil
 }
 
+// DeleteFileShareAcl implements pb.DockServer.DeleteFileShare
+func (ds *dockServer) DeleteFileShareAcl(ctx context.Context, opt *pb.DeleteFileShareAclOpts) (*pb.GenericResponse, error) {
+	// Get the storage drivers and do some initializations.
+	ds.FileShareDriver = filesharedrivers.Init(opt.GetDriverName())
+	defer filesharedrivers.Clean(ds.FileShareDriver)
+
+	log.Info("dock server receive delete file share acl request, vr =", opt)
+
+	fileshare, err := ds.FileShareDriver.DeleteFileShareAcl(opt)
+	if err != nil {
+		log.Error("when create file share in dock module:", err)
+		return pb.GenericResponseError(err), err
+	}
+	// TODO: maybe need to update status in DB.
+	return pb.GenericResponseResult(fileshare), nil
+}
+
 // CreateFileShare implements pb.DockServer.CreateFileShare
 func (ds *dockServer) CreateFileShare(ctx context.Context, opt *pb.CreateFileShareOpts) (*pb.GenericResponse, error) {
 	// Get the storage drivers and do some initializations.

--- a/pkg/model/fileshare.go
+++ b/pkg/model/fileshare.go
@@ -38,6 +38,9 @@ type FileShareAclSpec struct {
 
 	// The description of the fileshare acl.
 	Description string `json:"description,omitempty"`
+
+	// The uuid of the profile which the fileshare belongs to.
+	ProfileId string `json:"profileId,omitempty"`
 }
 
 // FileShareSpec is a schema for fileshare API. Fileshare will be created on some backend

--- a/pkg/model/fileshare.go
+++ b/pkg/model/fileshare.go
@@ -41,6 +41,11 @@ type FileShareAclSpec struct {
 
 	// The uuid of the profile which the fileshare belongs to.
 	ProfileId string `json:"profileId,omitempty"`
+
+	// Metadata should be kept until the scemantics between opensds fileshare
+	// and backend storage resouce description are clear.
+	// +optional
+	Metadata map[string]string `json:"metadata,omitempty"`
 }
 
 // FileShareSpec is a schema for fileshare API. Fileshare will be created on some backend

--- a/pkg/model/proto/model.pb.go
+++ b/pkg/model/proto/model.pb.go
@@ -2670,6 +2670,8 @@ type CreateFileShareAclOpts struct {
 	Context string `protobuf:"bytes,9,opt,name=context,proto3" json:"context,omitempty"`
 	// The name of the file share, required.
 	Name string `protobuf:"bytes,10,opt,name=name,proto3" json:"name,omitempty"`
+	// The metadata of the file share, optional.
+	Metadata map[string]string `protobuf:"bytes,11,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -2734,6 +2736,110 @@ func (m *CreateFileShareAclOpts) GetName() string {
 		return m.Name
 	}
 	return ""
+}
+
+func (m *CreateFileShareAclOpts) GetMetadata() map[string]string {
+	if m != nil {
+		return m.Metadata
+	}
+	return nil
+}
+
+// CreateFileShareOpts is a structure which indicates all required properties for creating a file share.
+type DeleteFileShareAclOpts struct {
+	// The uuid of the file share, optional when creating.
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	// The uuid of the file share that snapshot belongs to, required.
+	FileShareId string `protobuf:"bytes,2,opt,name=fileshareId,proto3" json:"fileshareId,omitempty"`
+	// The description of the file share, optional.
+	Description string `protobuf:"bytes,3,opt,name=description,proto3" json:"description,omitempty"`
+	// The type of access. Ex: IP based.
+	Type string `protobuf:"bytes,4,opt,name=type,proto3" json:"type,omitempty"`
+	// The accessCapability for fileshare.
+	AccessCapability []string `protobuf:"bytes,5,opt,name=accessCapability,proto3" json:"accesscapability,omitempty"`
+	// accessTo of the fileshare.
+	AccessTo []string `protobuf:"bytes,6,opt,name=accessTo,proto3" json:"accessto,omitempty"`
+	// The Serialized profile
+	Profile string `protobuf:"bytes,7,opt,name=profile,proto3" json:"profile,omitempty"`
+	// The storage driver type.
+	DriverName string `protobuf:"bytes,8,opt,name=driverName,proto3" json:"driverName,omitempty"`
+	// The Context
+	Context string `protobuf:"bytes,9,opt,name=context,proto3" json:"context,omitempty"`
+	// The name of the file share, required.
+	Name string `protobuf:"bytes,10,opt,name=name,proto3" json:"name,omitempty"`
+	// The metadata of the file share, optional.
+	Metadata map[string]string `protobuf:"bytes,11,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *DeleteFileShareAclOpts) Reset()         { *m = DeleteFileShareAclOpts{} }
+func (m *DeleteFileShareAclOpts) String() string { return proto.CompactTextString(m) }
+func (*DeleteFileShareAclOpts) ProtoMessage()    {}
+func (*DeleteFileShareAclOpts) Descriptor() ([]byte, []int) {
+	return fileDescriptor_4c16552f9fdb66d8, []int{21}
+}
+
+func (m *DeleteFileShareAclOpts) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_DeleteFileShareAclOpts.Unmarshal(m, b)
+}
+func (m *DeleteFileShareAclOpts) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_DeleteFileShareAclOpts.Marshal(b, m, deterministic)
+}
+func (m *DeleteFileShareAclOpts) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_DeleteFileShareAclOpts.Merge(m, src)
+}
+func (m *DeleteFileShareAclOpts) XXX_Size() int {
+	return xxx_messageInfo_CreateFileShareAclOpts.Size(m)
+}
+func (m *DeleteFileShareAclOpts) XXX_DiscardUnknown() {
+	xxx_messageInfo_DeleteFileShareAclOpts.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_DeleteFileShareAclOpts proto.InternalMessageInfo
+
+func (m *DeleteFileShareAclOpts) GetDriverName() string {
+	if m != nil {
+		return m.DriverName
+	}
+	return ""
+}
+
+func (m *DeleteFileShareAclOpts) GetAccessCapability() []string {
+	if m != nil {
+		return m.AccessCapability
+	}
+	return nil
+}
+
+func (m *DeleteFileShareAclOpts) GetAccessTo() []string {
+	if m != nil {
+		return m.AccessTo
+	}
+	return nil
+}
+
+func (m *DeleteFileShareAclOpts) GetContext() string {
+	if m != nil {
+		return m.Context
+	}
+	return ""
+}
+
+func (m *DeleteFileShareAclOpts) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
+}
+
+func (m *DeleteFileShareAclOpts) GetMetadata() map[string]string {
+	if m != nil {
+		return m.Metadata
+	}
+	return nil
 }
 
 // CreateFileShareOpts is a structure which indicates all required properties for creating a file share.
@@ -3591,6 +3697,8 @@ func init() {
 	proto.RegisterMapType((map[string]string)(nil), "proto.CreateFileShareSnapshotOpts.MetadataEntry")
 	proto.RegisterType((*CreateFileShareAclOpts)(nil), "proto.CreateFileShareAclOpts")
 	proto.RegisterMapType((map[string]string)(nil), "proto.CreateFileShareAclOpts.MetadataEntry")
+	proto.RegisterType((*DeleteFileShareAclOpts)(nil), "proto.DeleteFileShareAclOpts")
+	proto.RegisterMapType((map[string]string)(nil), "proto.DeleteFileShareAclOpts.MetadataEntry")
 	proto.RegisterType((*DeleteFileShareSnapshotOpts)(nil), "proto.DeleteFileShareSnapshotOpts")
 	proto.RegisterType((*GenericResponse)(nil), "proto.GenericResponse")
 	proto.RegisterType((*GenericResponse_Result)(nil), "proto.GenericResponse.Result")
@@ -5122,8 +5230,10 @@ var _ProvisionDock_serviceDesc = grpc.ServiceDesc{
 type FileShareControllerClient interface {
 	// Create a file share
 	CreateFileShare(ctx context.Context, in *CreateFileShareOpts, opts ...grpc.CallOption) (*GenericResponse, error)
-	// Create a file share
+	// Create a file share acl
 	CreateFileShareAcl(ctx context.Context, in *CreateFileShareAclOpts, opts ...grpc.CallOption) (*GenericResponse, error)
+	// delete a file share acl
+	DeleteFileShareAcl(ctx context.Context, in *DeleteFileShareAclOpts, opts ...grpc.CallOption) (*GenericResponse, error)
 	// Delete a file share
 	DeleteFileShare(ctx context.Context, in *DeleteFileShareOpts, opts ...grpc.CallOption) (*GenericResponse, error)
 	// Create a file share snapshot
@@ -5167,6 +5277,15 @@ func (c *fileShareControllerClient) DeleteFileShare(ctx context.Context, in *Del
 	return out, nil
 }
 
+func (c *fileShareControllerClient) DeleteFileShareAcl(ctx context.Context, in *DeleteFileShareAclOpts, opts ...grpc.CallOption) (*GenericResponse, error) {
+	out := new(GenericResponse)
+	err := c.cc.Invoke(ctx, "/proto.FileShareController/DeleteFileShareAcl", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *fileShareControllerClient) CreateFileShareSnapshot(ctx context.Context, in *CreateFileShareSnapshotOpts, opts ...grpc.CallOption) (*GenericResponse, error) {
 	out := new(GenericResponse)
 	err := c.cc.Invoke(ctx, "/proto.FileShareController/CreateFileShareSnapshot", in, out, opts...)
@@ -5191,6 +5310,8 @@ type FileShareControllerServer interface {
 	CreateFileShare(context.Context, *CreateFileShareOpts) (*GenericResponse, error)
 	// Create a file share Acl
 	CreateFileShareAcl(context.Context, *CreateFileShareAclOpts) (*GenericResponse, error)
+	// Delete a file share Acl
+	DeleteFileShareAcl(context.Context, *DeleteFileShareAclOpts) (*GenericResponse, error)
 	// Delete a file share
 	DeleteFileShare(context.Context, *DeleteFileShareOpts) (*GenericResponse, error)
 	// Create a file share snapshot
@@ -5211,6 +5332,9 @@ func (*UnimplementedFileShareControllerServer) CreateFileShareAcl(ctx context.Co
 }
 func (*UnimplementedFileShareControllerServer) DeleteFileShare(ctx context.Context, req *DeleteFileShareOpts) (*GenericResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method DeleteFileShare not implemented")
+}
+func (*UnimplementedFileShareControllerServer) DeleteFileShareAcl(ctx context.Context, req *CreateFileShareAclOpts) (*GenericResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteFileShareAcl not implemented")
 }
 func (*UnimplementedFileShareControllerServer) CreateFileShareSnapshot(ctx context.Context, req *CreateFileShareSnapshotOpts) (*GenericResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method CreateFileShareSnapshot not implemented")
@@ -5277,6 +5401,24 @@ func _FileShareController_DeleteFileShare_Handler(srv interface{}, ctx context.C
 	return interceptor(ctx, in, info, handler)
 }
 
+func _FileShareController_DeleteFileShareAcl_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeleteFileShareAclOpts)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(FileShareControllerServer).DeleteFileShareAcl(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/proto.FileShareController/DeleteFileShareAcl",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(FileShareControllerServer).DeleteFileShareAcl(ctx, req.(*DeleteFileShareAclOpts))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _FileShareController_CreateFileShareSnapshot_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(CreateFileShareSnapshotOpts)
 	if err := dec(in); err != nil {
@@ -5330,6 +5472,10 @@ var _FileShareController_serviceDesc = grpc.ServiceDesc{
 			Handler:    _FileShareController_DeleteFileShare_Handler,
 		},
 		{
+			MethodName: "DeleteFileShareAcl",
+			Handler:    _FileShareController_DeleteFileShareAcl_Handler,
+		},
+		{
 			MethodName: "CreateFileShareSnapshot",
 			Handler:    _FileShareController_CreateFileShareSnapshot_Handler,
 		},
@@ -5350,6 +5496,8 @@ type FileShareDockClient interface {
 	CreateFileShare(ctx context.Context, in *CreateFileShareOpts, opts ...grpc.CallOption) (*GenericResponse, error)
 	// Create a file share acl
 	CreateFileShareAcl(ctx context.Context, in *CreateFileShareAclOpts, opts ...grpc.CallOption) (*GenericResponse, error)
+	// Delete a file share acl
+	DeleteFileShareAcl(ctx context.Context, in *DeleteFileShareAclOpts, opts ...grpc.CallOption) (*GenericResponse, error)
 	// Delete a file share
 	DeleteFileShare(ctx context.Context, in *DeleteFileShareOpts, opts ...grpc.CallOption) (*GenericResponse, error)
 	// Create a file share snapshot
@@ -5393,6 +5541,15 @@ func (c *fileShareDockClient) DeleteFileShare(ctx context.Context, in *DeleteFil
 	return out, nil
 }
 
+func (c *fileShareDockClient) DeleteFileShareAcl(ctx context.Context, in *DeleteFileShareAclOpts, opts ...grpc.CallOption) (*GenericResponse, error) {
+	out := new(GenericResponse)
+	err := c.cc.Invoke(ctx, "/proto.FileShareDock/DeleteFileShareAcl", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *fileShareDockClient) CreateFileShareSnapshot(ctx context.Context, in *CreateFileShareSnapshotOpts, opts ...grpc.CallOption) (*GenericResponse, error) {
 	out := new(GenericResponse)
 	err := c.cc.Invoke(ctx, "/proto.FileShareDock/CreateFileShareSnapshot", in, out, opts...)
@@ -5417,6 +5574,8 @@ type FileShareDockServer interface {
 	CreateFileShare(context.Context, *CreateFileShareOpts) (*GenericResponse, error)
 	// Create a file share
 	CreateFileShareAcl(context.Context, *CreateFileShareAclOpts) (*GenericResponse, error)
+	// Delete a file share acl
+	DeleteFileShareAcl(context.Context, *DeleteFileShareAclOpts) (*GenericResponse, error)
 	// Delete a file share
 	DeleteFileShare(context.Context, *DeleteFileShareOpts) (*GenericResponse, error)
 	// Create a file share snapshot
@@ -5437,6 +5596,9 @@ func (*UnimplementedFileShareDockServer) CreateFileShareAcl(ctx context.Context,
 }
 func (*UnimplementedFileShareDockServer) DeleteFileShare(ctx context.Context, req *DeleteFileShareOpts) (*GenericResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method DeleteFileShare not implemented")
+}
+func (*UnimplementedFileShareDockServer) DeleteFileShareAcl(ctx context.Context, req *CreateFileShareOpts) (*GenericResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteFileShareAcl not implemented")
 }
 func (*UnimplementedFileShareDockServer) CreateFileShareSnapshot(ctx context.Context, req *CreateFileShareSnapshotOpts) (*GenericResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method CreateFileShareSnapshot not implemented")
@@ -5503,6 +5665,24 @@ func _FileShareDock_DeleteFileShare_Handler(srv interface{}, ctx context.Context
 	return interceptor(ctx, in, info, handler)
 }
 
+func _FileShareDock_DeleteFileShareAcl_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeleteFileShareAclOpts)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(FileShareDockServer).DeleteFileShareAcl(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/proto.FileShareDock/DeleteFileShareAcl",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(FileShareDockServer).DeleteFileShareAcl(ctx, req.(*DeleteFileShareAclOpts))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _FileShareDock_CreateFileShareSnapshot_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(CreateFileShareSnapshotOpts)
 	if err := dec(in); err != nil {
@@ -5554,6 +5734,10 @@ var _FileShareDock_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "DeleteFileShare",
 			Handler:    _FileShareDock_DeleteFileShare_Handler,
+		},
+		{
+			MethodName: "DeleteFileShareAcl",
+			Handler:    _FileShareDock_DeleteFileShareAcl_Handler,
 		},
 		{
 			MethodName: "CreateFileShareSnapshot",

--- a/pkg/model/proto/model.proto
+++ b/pkg/model/proto/model.proto
@@ -166,6 +166,9 @@ service FileShareController {
     // Create a file share Acl
     rpc CreateFileShareAcl (CreateFileShareAclOpts) returns (GenericResponse){}
 
+    // Delete a file share Acl
+    rpc DeleteFileShareAcl (DeleteFileShareAclOpts) returns (GenericResponse){}
+
 }
 
 service FileShareDock {
@@ -184,6 +187,9 @@ service FileShareDock {
 
     // Create a file share Acl
     rpc CreateFileShareAcl (CreateFileShareAclOpts) returns (GenericResponse){}
+
+    // Delete a file share Acl
+    rpc DeleteFileShareAcl (DeleteFileShareAclOpts) returns (GenericResponse){}
 
 }
 
@@ -723,6 +729,32 @@ message DetachVolumeOpts {
 }
 
 // CreateFileShareAclOpts is a structure which indicates all required properties for creating a file share.
+message DeleteFileShareAclOpts {
+    // The uuid of the file share, optional when creating.
+    string id = 1;
+    // The fileshareId
+    string fileshareId = 2;
+    // The description
+    string description = 3;
+    // The type of access. Ex: IP based.
+    string type = 4
+    // The accessCapability for fileshare.
+    repeated string accessCapability = 5
+    // accessTo of the fileshare.
+    repeated string accessTo = 6
+    // The Serialized profile
+    string profile = 7;
+    // The driverName
+    string driverName = 8;
+    // The Context
+    string context = 9;
+    // The Name
+    string Name = 10;
+    // The metadata of the file share, optional.
+    map<string, string> metadata = 11;
+}
+
+// CreateFileShareAclOpts is a structure which indicates all required properties for creating a file share.
 message CreateFileShareAclOpts {
     // The uuid of the file share, optional when creating.
     string id = 1;
@@ -744,6 +776,8 @@ message CreateFileShareAclOpts {
     string context = 9;
     // The Name
     string Name = 10;
+    // The metadata of the file share, optional.
+    map<string, string> metadata = 11;
 }
 
 // CreateFileShareOpts is a structure which indicates all required properties for creating a file share.
@@ -832,7 +866,7 @@ message DeleteFileShareSnapshotOpts {
     // The Serialized profile
     string profile = 5;
     // The metadata of the fileshare, optional.
-    map<string, string> metadata = 9;
+    map<string, string> metadata = 6;
 }
 
 // Generic response, it return:

--- a/pkg/model/proto/model.proto
+++ b/pkg/model/proto/model.proto
@@ -831,6 +831,8 @@ message DeleteFileShareSnapshotOpts {
     string context = 4;
     // The Serialized profile
     string profile = 5;
+    // The metadata of the fileshare, optional.
+    map<string, string> metadata = 9;
 }
 
 // Generic response, it return:

--- a/testutils/controller/testing/client.go
+++ b/testutils/controller/testing/client.go
@@ -121,6 +121,36 @@ func (_m *Client) CreateFileShareAcl(ctx context.Context, in *proto.CreateFileSh
 	return r0, r1
 }
 
+// CreateFileShareAcl provides a mock function with given fields: ctx, in, opts
+func (_m *Client) DeleteFileShareAcl(ctx context.Context, in *proto.DeleteFileShareAclOpts, opts ...grpc.CallOption) (*proto.GenericResponse, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, in)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *proto.GenericResponse
+	if rf, ok := ret.Get(0).(func(context.Context, *proto.DeleteFileShareAclOpts, ...grpc.CallOption) *proto.GenericResponse); ok {
+		r0 = rf(ctx, in, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*proto.GenericResponse)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *proto.DeleteFileShareAclOpts, ...grpc.CallOption) error); ok {
+		r1 = rf(ctx, in, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // CreateReplication provides a mock function with given fields: ctx, in, opts
 func (_m *Client) CreateReplication(ctx context.Context, in *proto.CreateReplicationOpts, opts ...grpc.CallOption) (*proto.GenericResponse, error) {
 	_va := make([]interface{}, len(opts))

--- a/testutils/driver/sample.go
+++ b/testutils/driver/sample.go
@@ -134,6 +134,10 @@ func (d *Driver) CreateFileShareAcl(opt *pb.CreateFileShareAclOpts) (*model.File
 	return &SampleFileSharesAcl[0], nil
 }
 
+func (d *Driver) DeleteFileShareAcl(opt *pb.DeleteFileShareAclOpts) (*model.FileShareAclSpec, error) {
+	return &SampleFileSharesAcl[0], nil
+}
+
 // CreateFileShareSnapshot
 func (d *Driver) CreateFileShareSnapshot(opt *pb.CreateFileShareSnapshotOpts) (*model.FileShareSnapshotSpec, error) {
 	return &SampleFileShareSnapshots[0], nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
It add Profile to CreateFileShareAcl controller and fix issue related to snapshot metadata.
It also has dock and controller logic for deleteaccessAPI

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
