### PR TITLE
Patch 799 - Create file share fails because of no availability pool

### DIFF
--- a/examples/driver/nfs.yaml
+++ b/examples/driver/nfs.yaml
@@ -1,0 +1,37 @@
+# Copyright 2019 The OpenSDS Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+tgtBindIp: 100.64.40.97
+tgtConfDir: /etc/tgt/conf.d
+pool:
+  opensds-files-default:
+    diskType: NL-SAS
+    availabilityZone: default
+    multiAttach: true
+    storageType: file
+    extras:
+      dataStorage:
+        provisioningPolicy: Thin
+        isSpaceEfficient: false
+        storageAccessCapability:
+          - Read
+          - Write
+          - Execute
+      ioConnectivity:
+        accessProtocol: nfs
+        maxIOPS: 7000000
+        maxBWS: 600
+      advanced:
+        diskType: SSD
+        latency: 5ms

--- a/install/devsds/lib/lvm.sh
+++ b/install/devsds/lib/lvm.sh
@@ -187,7 +187,10 @@ pool:
       dataStorage:
         provisioningPolicy: Thin
         isSpaceEfficient: false
-        StorageAccessCapability: ['Read', 'Write', 'Execute']
+        storageAccessCapability:
+         - Read
+         - Write
+         - Execute
       ioConnectivity:
         accessProtocol: nfs
         maxIOPS: 7000000


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Patch 799 - Create file share fails because of no availability pool

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
