### PR TITLE
nvme over diverse fabric supoort & nbp nvme-tcp support

### DIFF
--- a/contrib/connector/nvmeof/nvmeof_helper.go
+++ b/contrib/connector/nvmeof/nvmeof_helper.go
@@ -33,7 +33,7 @@ type ConnectorInfo struct {
 	Nqn       string `mapstructure:"targetNQN"`     //NVMe subsystem name to the volume to be connected
 	TgtPort   string `mapstructure:"targetPort"`    //NVMe target port that hosts the nqn sybsystem
 	TgtPortal string `mapstructure:"targetIP"`      //NVMe target ip that hosts the nqn sybsystem
-	TranType  string `mapstructure:"transporType "` // Nvme transport type
+	TranType  string `mapstructure:"transporType"` // Nvme transport type
 	HostNqn   string `mapstructure:"hostNqn"`       // host nqn
 }
 
@@ -52,8 +52,8 @@ func GetInitiator() ([]string, error) {
 
 	lines := strings.Split(string(res), "\n")
 	for _, l := range lines {
-		if strings.Contains(l, "UUID:") {
-			tmp := iniNvmePrefix + strings.Split(l, ":")[1]
+		if strings.Contains(l, "UUID: ") {
+			tmp := iniNvmePrefix + strings.Split(l, ": ")[1]
 			nqns = append(nqns, tmp)
 			log.Printf("Found the following nqns: %s", nqns)
 			return nqns, nil
@@ -131,7 +131,7 @@ func Discovery(connMap map[string]interface{}) error {
 	conn := ParseNvmeofConnectInfo(connMap)
 	targetip := conn.TgtPortal
 	targetport := conn.TgtPort
-	info, err := connector.ExecCmd("nvme", "discover", "-t", "rdma", "-a", targetip, "-s", targetport)
+	info, err := connector.ExecCmd("nvme", "discover", "-t", "tcp", "-a", targetip, "-s", targetport)
 	if err != nil {
 		log.Printf("Error encountered in send targets:%v, %v\n", err, info)
 		return err
@@ -146,11 +146,17 @@ func Connect(connMap map[string]interface{}) (string, error) {
 	connNqn := conn.Nqn
 	targetPortal := conn.TgtPortal
 	port := conn.TgtPort
-	nvmeTransportType := "rdma"
-	log.Printf("conn information:%s, %s, %s ", connNqn, targetPortal, port)
+	nvmeTransportType := conn.TranType 
+ 	hostName := conn.HostNqn
+	
+	cmd := "nvme connect -t " + nvmeTransportType + " -n " + connNqn + " -s " + port + " -a " + targetPortal
+       if hostName != "ALL" {
+               cmd += " -q " + hostName
+       }
+       //log.Printf("conn information:%s, %s, %s ", connNqn, targetPortal, port)
 
-	_, err := connector.ExecCmd("nvme", "connect", "-t",
-		nvmeTransportType, "-n", connNqn, "-a", targetPortal, "-s", port)
+       _, err := connector.ExecCmd("/bin/bash", "-c", cmd)
+
 	if err != nil {
 		log.Println("Failed to connect to NVMe nqn :", connNqn)
 		return "", err

--- a/contrib/drivers/lvm/targets/nvmeof.go
+++ b/contrib/drivers/lvm/targets/nvmeof.go
@@ -183,13 +183,13 @@ func (t *NvmeoftgtTarget) CreateNvmeofTarget(volId, tgtNqn, path, initiator, tra
 	} else if subexisted == "" {
 		log.Infof("add new nqn subsystem %s", tgtNqn)
 		subexisted, err = t.AddNvmeofSubsystem(volId, tgtNqn, path, initiator)
-		log.Infof("new subdir:", subexisted)
+		log.Infof("new subdir: %s", subexisted)
 	} else {
 		log.Infof("%s subsystem has existed", tgtNqn)
 	}
 
 	subexisted =  NvmetDir + "/subsystems/" + tgtNqn 
-	log.Infof("new subdir:", subexisted)
+	log.Infof("new subdir: %s", subexisted)
 //	subexisted, err = t.GetNvmeofSubsystem(tgtNqn)
 //	log.Infof("new subdir: %s ", subexisted)
 //	if  subexisted == "" {
@@ -329,7 +329,7 @@ func (t *NvmeoftgtTarget) RemoveNvmeofSubsystem(volId, nqn string) error {
 }
 
 func (t *NvmeoftgtTarget) RemoveNvmeofPort(nqn, transtype string) error {
-	log.Infof("removing nvmeof port", transtype)
+	log.Infof("removing nvmeof port %s", transtype)
 	portid := t.convertTranstype(transtype)
 
 	portpath := NvmetDir + "/ports/" + portid + "/subsystems/" + nqn
@@ -351,7 +351,7 @@ func (t *NvmeoftgtTarget) RemoveNvmeofPort(nqn, transtype string) error {
 }
 
 func (t *NvmeoftgtTarget) RemoveNvmeofTarget(volId, nqn, transtype string) error {
-	log.Infof("removing target", nqn)
+	log.Infof("removing target %s", nqn)
 	if tgtexisted, err := t.GetNvmeofTarget(nqn, transtype); err != nil {
 		log.Errorf("can not get nvmeof target %s with type %s", nqn, transtype)
 		return err

--- a/contrib/drivers/lvm/targets/targets.go
+++ b/contrib/drivers/lvm/targets/targets.go
@@ -81,7 +81,17 @@ type nvmeofTarget struct {
 
 func (t *nvmeofTarget) CreateExport(volId, path, hostIp, initiator string, chapAuth []string) (map[string]interface{}, error) {
 	tgtNqn := nvmeofTgtPrefix + volId
-	if err := t.CreateNvmeofTarget(volId, tgtNqn, path, hostIp, initiator, chapAuth); err != nil {
+	// So far nvmeof transtport type is defaultly set as tcp because of its widely use, but it can also be rdma/fc.
+	// The difference of transport type leads to different performance of volume attachment latency and iops.
+	// This choice of transport type depends on 3 following factors:
+	// 1. initiator's latency/iops requiremnet
+	// 2. initiator's availiable nic(whether the inititator can use rdma/fc/tcpip)
+	// 3. target server's availiable nic(whether the target server can use rdma/fc/tcpip)
+	// According to the opensds architecture, it is a more approprite way for the opensds controller
+	//to take the decision in the future.
+	var transtype string
+	transtype = "tcp"
+	if err := t.CreateNvmeofTarget(volId, tgtNqn, path, initiator, transtype); err != nil {
 		return nil, err
 	}
 	conn := map[string]interface{}{
@@ -89,17 +99,25 @@ func (t *nvmeofTarget) CreateExport(volId, path, hostIp, initiator string, chapA
 		"targetNQN":        tgtNqn,
 		"targetIP":         t.NvmeofTarget.(*NvmeoftgtTarget).BindIp,
 		"targetPort":       "4420",
+		"hostNqn":          initiator,
 		"discard":          false,
+		"transporType":     transtype,
 	}
-	if len(chapAuth) == 2 {
-		conn["authMethod"] = "chap"
-		conn["authUserName"] = chapAuth[0]
-		conn["authPassword"] = chapAuth[1]
-	}
+
 	return conn, nil
 }
 
 func (t *nvmeofTarget) RemoveExport(volId, hostIp string) error {
 	tgtNqn := nvmeofTgtPrefix + volId
-	return t.RemoveNvmeofTarget(volId, tgtNqn, hostIp)
+	// So far nvmeof transtport type is defaultly set as tcp because of its widely use, but it can also be rdma/fc.
+	// The difference of transport type leads to different performance of volume attachment latency and iops.
+	// This choice of transport type depends on 3 following factors:
+	// 1. initiator's latency/iops requiremnet
+	// 2. initiator's availiable nic(whether the inititator can use rdma/fc/tcpip)
+	// 3. target server's availiable nic(whether the target server can use rdma/fc/tcpip)
+	// According to the opensds architecture, it is a more approprite way for the opensds controller
+	//to take the decision in the future.
+	var transtype string
+	transtype = "tcp"
+	return t.RemoveNvmeofTarget(volId, tgtNqn, transtype)
 }

--- a/test/e2e/e2ef_test.go
+++ b/test/e2e/e2ef_test.go
@@ -299,7 +299,11 @@ func TestNvmeofAttachIssues(t *testing.T) {
 		t.Error("connect nvmeof attachment fail", err)
 		return
 	}
-
+        err = NvmeofVolumeAttachHost(t)
+        if err != nil {
+               t.Error("connect nvmeof attachment fail", err)
+                return
+        }
 	err = DeleteNvmeofAttach(t)
 	if err != nil {
 		t.Error("delete nvmeof attachment fail", err)
@@ -389,6 +393,50 @@ func DeleteNvmeofAttach(t *testing.T) error {
 		t.Error("delete attachment failed:", err)
 		return err
 	}
+}
+
+//Test Case:Nvmeof Volume Attach to specific host
+func NvmeofVolumeAttachHost(t *testing.T) error {
+       attc, err := PrepareNvmeofAttachmentHost(t)
+       if err != nil {
+               t.Error("Prepare Attachment Fail:", err)
+               return err
+       }
+       defer cleanVolumeAndAttachmentForTest(t, attc.VolumeId, attc.Id)
+       getatt, err := u.GetVolumeAttachment(attc.Id)
+       if err != nil || getatt.Status != "available" {
+               t.Errorf("attachment(%s) is not available: %v", attc.Id, err)
+               return err
+       }
+
+       t.Log("Begin to Scan Volume:")
+       t.Log("getatt.AccessProtocol", getatt.AccessProtocol)
+       t.Log("getatt.Metadata", getatt.ConnectionData)
+
+       output, _ := execCmd("/bin/bash", "-c", "ps -ef")
+       t.Log(output)
+       //execute bin file
+       conn, err := json.Marshal(&getatt.ConnectionData)
+       if err != nil {
+               t.Error("Failed to marshal connection data:", err)
+               return err
+       }
+       accPro := getatt.AccessProtocol
+       output, err = execCmd("sudo", "./volume-connector",
+               "attach", string(conn), accPro)
+       if err != nil {
+               t.Error("Failed to attach volume:", output, err)
+               return err
+       }
+       t.Log(output)
+       t.Log("Nvmeof Volume attach yoyo success!")
+       // detach it
+       err = NvmeofVolumeDetach(t, attc)
+       if err != nil {
+               t.Error("detach failed")
+               return err
+       }
+       return nil
 }
 
 //Test Case:Nvmeof Volume Attach
@@ -577,6 +625,30 @@ func PrepareNvmeofAttachment(t *testing.T) (*model.VolumeAttachmentSpec, error) 
 
 	t.Log("prepare nvmeof Volume Attachment Success")
 	return attc, nil
+}
+
+// prepare nvmeof attachment availible to specific host
+func PrepareNvmeofAttachmentHost(t *testing.T) (*model.VolumeAttachmentSpec, error) {
+       vol, err := PrepareNvmeVolume()
+       if err != nil {
+               t.Error("Prepare nvmeof  Volume Fail", err)
+               return nil, err
+       }
+
+       var body = &model.VolumeAttachmentSpec{
+               VolumeId: vol.Id,
+               HostInfo: model.HostInfo{
+                       Initiator: "nqn.ini.1A2B3C4D5E6F7G8H",
+              },
+       }
+       attc, err := u.CreateVolumeAttachment(body)
+       if err != nil {
+               t.Error("prepare volume attachment failed:", err)
+               return nil, err
+       }
+
+       t.Log("prepare nvmeof Volume Attachment Success")
+       return attc, nil
 }
 
 func cleanVolumeForTest(t *testing.T, volID string) {


### PR DESCRIPTION
Signed-off-by: ericysx ericyangshixin@gmail.com

What this PR does / why we need it:
1. support for diverse nvme over fabric connection(nvme-tcp, nvme-rdma ) .
2. modify the nvme target code to enhance scalability.
3. add support for nvme-tcp in nbp csi.

Which issue this PR fixes(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
None

**Special notes for your reviewer**:
This patch is highly recommended to be deployed with kernel version 5.0  and above, where all the nvme over fabric features can be supported.

**Release note**:
None
