### PR TITLE
Fix for #729 - Removed Pre-defined profile properties

### DIFF
--- a/pkg/api/controllers/profile.go
+++ b/pkg/api/controllers/profile.go
@@ -28,7 +28,6 @@ import (
 	c "github.com/opensds/opensds/pkg/context"
 	"github.com/opensds/opensds/pkg/db"
 	"github.com/opensds/opensds/pkg/model"
-	"github.com/opensds/opensds/pkg/utils"
 	"github.com/opensds/opensds/pkg/utils/constants"
 )
 
@@ -60,30 +59,6 @@ func (p *ProfilePortal) CreateProfile() {
 	case constants.Block:
 		break
 	case constants.File:
-		if pp := profile.ProvisioningProperties; pp.IsEmpty() {
-			errMsg := fmt.Sprintf("parse profile request body failed : Please provide ProvisionProperties")
-			p.ErrorHandle(model.ErrorBadRequest, errMsg)
-			return
-		} else {
-			if ds := pp.DataStorage; !ds.IsEmpty() {
-				if len(ds.StorageAccessCapability) == 0 {
-					errMsg := fmt.Sprintf("parse profile request body failed %v is invalid storageaccesscapability",
-						ds.StorageAccessCapability)
-					p.ErrorHandle(model.ErrorBadRequest, errMsg)
-					return
-				} else {
-					for _, x := range ds.StorageAccessCapability {
-						if !utils.Contains(StorageAccessCapabilities, x) {
-							errMsg := fmt.Sprintf("parse profile request body failed %v is invalid storageaccesscapability",
-								ds.StorageAccessCapability)
-							p.ErrorHandle(model.ErrorBadRequest, errMsg)
-							return
-						}
-					}
-				}
-
-			}
-		}
 		break
 	default:
 		errMsg := fmt.Sprintf("parse profile request body failed: %v is invalid storagetype", stype)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This is to fix https://github.com/opensds/opensds/issues/729

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Profile for file share has some pre-defined properties

**Special notes for your reviewer**:
Sample commands to execute and verify the fix
```
root@shruthi-VirtualBox:~/go/src/github.com/opensds/opensds# curl --header "Content-Type: application/json" --data '{"name":"f12", "description":"file share test", "storageType":"file"}' http://127.0.0.1:50040/v1beta/e93b4c0934da416eb9c8d120c5d04d96/profiles
{"id":"e372f004-b2a9-4ffe-8903-a0f6a11563ee","createdAt":"2019-06-13T12:04:25","updatedAt":"","name":"f12","description":"file share test","storageType":"file","provisioningProperties":{"dataStorage":{"isSpaceEfficient":false},"ioConnectivity":{}},"replicationProperties":{"dataProtection":{"isIsolated":false},"replicaInfos":{}},"snapshotProperties":{"schedule":{},"retention":{},"topology":{}},"dataProtectionProperties":{"dataProtection":{"isIsolated":false}}}
root@shruthi-VirtualBox:~/go/src/github.com/opensds/opensds# osdsctl profile list
WARNING: OPENSDS_ENDPOINT is not specified, use default(http://localhost:50040)
WARNING: Not found Env OPENSDS_AUTH_STRATEGY, use default(noauth)
+--------------------------------------+---------+-----------------+-------------+
| Id                                   | Name    | Description     | StorageType |
+--------------------------------------+---------+-----------------+-------------+
| ecd0fe58-4a1d-445d-924c-deb9a991c646 | default | default policy  | file        |
| e372f004-b2a9-4ffe-8903-a0f6a11563ee | f12     | file share test | file        |
| 999977f2-5a52-4f64-9cc5-7d6df6685993 | default | default policy  | block       |
+--------------------------------------+---------+-----------------+-------------+
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
