### PR TITLE
Fix #758 - Add precheck when deleting profile

### DIFF
--- a/pkg/api/controllers/profile.go
+++ b/pkg/api/controllers/profile.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"strings"
 
+	log "github.com/golang/glog"
 	"github.com/opensds/opensds/pkg/api/policy"
 	c "github.com/opensds/opensds/pkg/context"
 	"github.com/opensds/opensds/pkg/db"
@@ -34,8 +35,6 @@ import (
 type ProfilePortal struct {
 	BasePortal
 }
-
-var StorageAccessCapabilities = []string{constants.Read, constants.Write, constants.Execute}
 
 func (p *ProfilePortal) CreateProfile() {
 	if !policy.Authorize(p.Ctx, "profile:create") {
@@ -191,7 +190,39 @@ func (p *ProfilePortal) DeleteProfile() {
 		return
 	}
 
-	if err = db.C.DeleteProfile(ctx, profile.Id); err != nil {
+	// Check the depedency before deletion of profile
+	// If no dependency then only allow user to delete profile
+	// 1. Check the volumes created through that profile
+	// 2. Check the fileshares created through that profile
+	if profile.StorageType == constants.Block {
+		vols, err := db.C.ListVolumesByProfileId(ctx, id)
+		if err != nil {
+			errMsg := fmt.Sprintf("failed to fetch volumes for specified profile: %v", err)
+			p.ErrorHandle(model.ErrorNotFound, errMsg)
+			return
+		}
+		if len(vols) > 0 {
+			errMsg := fmt.Sprintf("There are dependent volumes : %v for the specified profile %v", vols, id)
+			p.ErrorHandle(model.ErrorBadRequest, errMsg)
+			return
+		}
+	} else {
+		fileshares, err := db.C.ListFileSharesByProfileId(ctx, id)
+		if err != nil {
+			errMsg := fmt.Sprintf("failed to fetch fileshares for specified profileId: %v", err)
+			p.ErrorHandle(model.ErrorNotFound, errMsg)
+			return
+		}
+		if len(fileshares) > 0 {
+			errMsg := fmt.Sprintf("There are dependent fileshares : %v for the specified profile %v", fileshares, id)
+			p.ErrorHandle(model.ErrorBadRequest, errMsg)
+			return
+		}
+	}
+
+	log.V(5).Infof("There are no dependecies on the specified profile, so deleting : %v", profile)
+	err = db.C.DeleteProfile(ctx, profile.Id)
+	if err != nil {
 		errMsg := fmt.Sprintf("delete profiles failed: %v", err)
 		p.ErrorHandle(model.ErrorInternalServer, errMsg)
 		return

--- a/pkg/api/controllers/profile_test.go
+++ b/pkg/api/controllers/profile_test.go
@@ -249,6 +249,8 @@ func TestDeleteProfile(t *testing.T) {
 		mockClient := new(dbtest.Client)
 		mockClient.On("GetProfile", c.NewAdminContext(), "2f9c0a04-66ef-11e7-ade2-43158893e017").Return(
 			&SampleProfiles[1], nil)
+		mockClient.On("ListVolumesByProfileId", c.NewAdminContext(), "2f9c0a04-66ef-11e7-ade2-43158893e017").Return(
+			SampleVolumeNames, nil)
 		mockClient.On("DeleteProfile", c.NewAdminContext(), "2f9c0a04-66ef-11e7-ade2-43158893e017").Return(nil)
 		db.C = mockClient
 
@@ -266,6 +268,8 @@ func TestDeleteProfile(t *testing.T) {
 		mockClient := new(dbtest.Client)
 		mockClient.On("GetProfile", c.NewAdminContext(), "2f9c0a04-66ef-11e7-ade2-43158893e017").Return(
 			nil, errors.New("Invalid resource uuid"))
+		mockClient.On("ListVolumesByProfileId", c.NewAdminContext(), "2f9c0a04-66ef-11e7-ade2-43158893e017").Return(
+			nil, errors.New("Depency volumes"))
 		db.C = mockClient
 
 		r, _ := http.NewRequest("DELETE",
@@ -491,6 +495,8 @@ func TestDeleteFileShareProfile(t *testing.T) {
 		mockClient := new(dbtest.Client)
 		mockClient.On("GetProfile", c.NewAdminContext(), "2f9c0a04-66ef-11e7-ade2-43158893e017").Return(
 			&SampleFileShareProfiles[1], nil)
+		mockClient.On("ListFileSharesByProfileId", c.NewAdminContext(), "2f9c0a04-66ef-11e7-ade2-43158893e017").Return(
+			SampleShareNames, nil)
 		mockClient.On("DeleteProfile", c.NewAdminContext(), "2f9c0a04-66ef-11e7-ade2-43158893e017").Return(nil)
 		db.C = mockClient
 
@@ -508,6 +514,8 @@ func TestDeleteFileShareProfile(t *testing.T) {
 		mockClient := new(dbtest.Client)
 		mockClient.On("GetProfile", c.NewAdminContext(), "2f9c0a04-66ef-11e7-ade2-43158893e017").Return(
 			nil, errors.New("Invalid resource uuid"))
+		mockClient.On("ListFileSharesByProfileId", c.NewAdminContext(), "2f9c0a04-66ef-11e7-ade2-43158893e017").Return(
+			nil, errors.New("Depency FileShares"))
 		db.C = mockClient
 
 		r, _ := http.NewRequest("DELETE",

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -65,6 +65,8 @@ type Client interface {
 
 	ListFileShares(ctx *c.Context) ([]*model.FileShareSpec, error)
 
+	ListFileSharesByProfileId(ctx *c.Context, prfId string) ([]string, error)
+
 	ListFileSharesWithFilter(ctx *c.Context, m map[string][]string) ([]*model.FileShareSpec, error)
 
 	ListFileSharesAclWithFilter(ctx *c.Context, m map[string][]string) ([]*model.FileShareAclSpec, error)
@@ -146,6 +148,8 @@ type Client interface {
 	GetVolume(ctx *c.Context, volID string) (*model.VolumeSpec, error)
 
 	ListVolumes(ctx *c.Context) ([]*model.VolumeSpec, error)
+
+	ListVolumesByProfileId(ctx *c.Context, prfID string) ([]string, error)
 
 	ListVolumesWithFilter(ctx *c.Context, m map[string][]string) ([]*model.VolumeSpec, error)
 

--- a/pkg/db/drivers/etcd/etcd.go
+++ b/pkg/db/drivers/etcd/etcd.go
@@ -452,6 +452,21 @@ func (c *Client) ListFileShares(ctx *c.Context) ([]*model.FileShareSpec, error) 
 	return fileshares, nil
 }
 
+// ListFileSharesByProfileId
+func (c *Client) ListFileSharesByProfileId(ctx *c.Context, prfId string) ([]string, error) {
+	fileshares, err := c.ListFileShares(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var res_fileshares []string
+	for _, shares := range fileshares {
+		if shares.ProfileId == prfId {
+			res_fileshares = append(res_fileshares, shares.Name)
+		}
+	}
+	return res_fileshares, nil
+}
+
 // GetFileShareAcl
 func (c *Client) GetFileShareAcl(ctx *c.Context, aclID string) (*model.FileShareAclSpec, error) {
 	acl, err := c.getFileShareAcl(ctx, aclID)
@@ -1765,6 +1780,23 @@ func (c *Client) ListVolumes(ctx *c.Context) ([]*model.VolumeSpec, error) {
 		vols = append(vols, vol)
 	}
 	return vols, nil
+}
+
+// ListVolumesByProfileId
+func (c *Client) ListVolumesByProfileId(ctx *c.Context, prfID string) ([]string, error) {
+	vols, err := c.ListVolumes(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var resvols []string
+	for _, v := range vols {
+		if v.ProfileId == prfID {
+			resvols = append(resvols, v.Name)
+		}
+	}
+
+	return resvols, nil
+
 }
 
 var volume_sortKey string

--- a/test/integration/client_test.go
+++ b/test/integration/client_test.go
@@ -97,17 +97,6 @@ func TestClientListProfiles(t *testing.T) {
 	}
 }
 
-func TestClientDeleteProfile(t *testing.T) {
-	var prfID = "2f9c0a04-66ef-11e7-ade2-43158893e017"
-
-	if err := c.DeleteProfile(prfID); err != nil {
-		t.Error("delete profile in client failed:", err)
-		return
-	}
-
-	t.Log("Delete profile success!")
-}
-
 func TestClientAddCustomProperty(t *testing.T) {
 	var prfID = "2f9c0a04-66ef-11e7-ade2-43158893e017"
 	var body = &model.CustomPropertiesSpec{
@@ -442,6 +431,17 @@ func TestClientDeleteVolume(t *testing.T) {
 	}
 
 	t.Log("Delete volume success!")
+}
+
+func TestClientDeleteProfile(t *testing.T) {
+	var prfID = "2f9c0a04-66ef-11e7-ade2-43158893e017"
+
+	if err := c.DeleteProfile(prfID); err != nil {
+		t.Error("delete profile in client failed:", err)
+		return
+	}
+
+	t.Log("Delete profile success!")
 }
 
 // TODO: There are some deployment issues when testing Replicaiton operation,

--- a/testutils/collection/data.go
+++ b/testutils/collection/data.go
@@ -266,6 +266,8 @@ var (
 		},
 	}
 
+	SampleVolumeNames = []string{}
+
 	SampleVolumes = []model.VolumeSpec{
 		{
 			BaseModel: &model.BaseModel{
@@ -292,6 +294,8 @@ var (
 			SnapshotId:  "3769855c-a102-11e7-b772-17b880d2f537",
 		},
 	}
+
+	SampleShareNames = []string{}
 
 	SampleShares = []model.FileShareSpec{
 		{

--- a/testutils/db/fake.go
+++ b/testutils/db/fake.go
@@ -95,6 +95,11 @@ func (fc *FakeDbClient) ListFileShares(ctx *c.Context) ([]*model.FileShareSpec, 
 	return fshares, nil
 }
 
+// ListFileSharesByProfileId
+func (fc *FakeDbClient) ListFileSharesByProfileId(ctx *c.Context, prfId string) ([]string, error) {
+	return []string{}, nil
+}
+
 // UpdateFileShare
 func (fc *FakeDbClient) UpdateFileShare(ctx *c.Context, fshare *model.FileShareSpec) (*model.FileShareSpec, error) {
 	return &SampleFileShares[0], nil
@@ -370,6 +375,12 @@ func (fc *FakeDbClient) ListVolumes(ctx *c.Context) ([]*model.VolumeSpec, error)
 		vols = append(vols, &SampleVolumes[i])
 	}
 	return vols, nil
+}
+
+// ListVolumesByProfileId
+func (fc *FakeDbClient) ListVolumesByProfileId(ctx *c.Context, prfId string) ([]string, error) {
+
+	return []string{}, nil
 }
 
 // UpdateVolume

--- a/testutils/db/testing/client.go
+++ b/testutils/db/testing/client.go
@@ -12,28 +12,6 @@ type Client struct {
 	mock.Mock
 }
 
-func (_m *Client) GetDefaultProfileFileShare(ctx *context.Context) (*model.ProfileSpec, error) {
-	ret := _m.Called(ctx)
-
-	var r0 *model.ProfileSpec
-	if rf, ok := ret.Get(0).(func(*context.Context) *model.ProfileSpec); ok {
-		r0 = rf(ctx)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*model.ProfileSpec)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(*context.Context) error); ok {
-		r1 = rf(ctx)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // AddCustomProperty provides a mock function with given fields: ctx, prfID, custom
 func (_m *Client) AddCustomProperty(ctx *context.Context, prfID string, custom model.CustomPropertiesSpec) (*model.CustomPropertiesSpec, error) {
 	ret := _m.Called(ctx, prfID, custom)
@@ -489,6 +467,29 @@ func (_m *Client) ExtendVolume(ctx *context.Context, vol *model.VolumeSpec) (*mo
 
 // GetDefaultProfile provides a mock function with given fields: ctx
 func (_m *Client) GetDefaultProfile(ctx *context.Context) (*model.ProfileSpec, error) {
+	ret := _m.Called(ctx)
+
+	var r0 *model.ProfileSpec
+	if rf, ok := ret.Get(0).(func(*context.Context) *model.ProfileSpec); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.ProfileSpec)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetDefaultProfileFileShare provides a mock function with given fields: ctx
+func (_m *Client) GetDefaultProfileFileShare(ctx *context.Context) (*model.ProfileSpec, error) {
 	ret := _m.Called(ctx)
 
 	var r0 *model.ProfileSpec
@@ -1039,6 +1040,29 @@ func (_m *Client) ListFileSharesAclWithFilter(ctx *context.Context, m map[string
 	return r0, r1
 }
 
+// ListFileSharesByProfileId provides a mock function with given fields: ctx, prfId
+func (_m *Client) ListFileSharesByProfileId(ctx *context.Context, prfId string) ([]string, error) {
+	ret := _m.Called(ctx, prfId)
+
+	var r0 []string
+	if rf, ok := ret.Get(0).(func(*context.Context, string) []string); ok {
+		r0 = rf(ctx, prfId)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*context.Context, string) error); ok {
+		r1 = rf(ctx, prfId)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // ListFileSharesWithFilter provides a mock function with given fields: ctx, m
 func (_m *Client) ListFileSharesWithFilter(ctx *context.Context, m map[string][]string) ([]*model.FileShareSpec, error) {
 	ret := _m.Called(ctx, m)
@@ -1407,6 +1431,29 @@ func (_m *Client) ListVolumesByGroupId(ctx *context.Context, vgId string) ([]*mo
 	return r0, r1
 }
 
+// ListVolumesByProfileId provides a mock function with given fields: ctx, prfID
+func (_m *Client) ListVolumesByProfileId(ctx *context.Context, prfID string) ([]string, error) {
+	ret := _m.Called(ctx, prfID)
+
+	var r0 []string
+	if rf, ok := ret.Get(0).(func(*context.Context, string) []string); ok {
+		r0 = rf(ctx, prfID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*context.Context, string) error); ok {
+		r1 = rf(ctx, prfID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // ListVolumesWithFilter provides a mock function with given fields: ctx, m
 func (_m *Client) ListVolumesWithFilter(ctx *context.Context, m map[string][]string) ([]*model.VolumeSpec, error) {
 	ret := _m.Called(ctx, m)
@@ -1490,7 +1537,7 @@ func (_m *Client) UpdateFileShare(ctx *context.Context, fshare *model.FileShareS
 	return r0, r1
 }
 
-// UpdateFileShareAcl provides a mock function with given fields: ctx, fshare
+// UpdateFileShareAcl provides a mock function with given fields: ctx, acl
 func (_m *Client) UpdateFileShareAcl(ctx *context.Context, acl *model.FileShareAclSpec) (*model.FileShareAclSpec, error) {
 	ret := _m.Called(ctx, acl)
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fix for #758 Add precheck when deleting profile

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Added few test results to verify deletion.
```
root@shruthi-VirtualBox:~/go/src/github.com/opensds/opensds# curl -X DELETE http://127.0.0.1:50040/v1beta/e93b4c0934da416eb9c8d120c5d04d96/profiles/638658b0-5952-47f9-bad6-ae9531a33d51
{"code":400,"message":"There are dependent volumes : [11vol vol4 vol3 vol3 vol1 vol2] for the specified profile 638658b0-5952-47f9-bad6-ae9531a33d51"}

root@shruthi-VirtualBox:~/go/src/github.com/opensds/opensds# curl -X DELETE http://127.0.0.1:50040/v1beta/e93b4c0934da416eb9c8d120c5d04d96/profiles/b859e948-42e7-450b-a617-bb1b1c5ea068
{"code":400,"message":"There are dependent fileshares : [fileshare3 fileshare2 fileshare1] for the specified profile b859e948-42e7-450b-a617-bb1b1c5ea068"}

root@shruthi-VirtualBox:~/go/src/github.com/opensds/opensds# curl -X DELETE http://127.0.0.1:50040/v1beta/e93b4c0934da416eb9c8d120c5d04d96/profiles/a637b596-0987-4149-a216-1ec6dcff8c5b
{"code":400,"message":"There are dependent filesharesnapshots : [snap5] for the specified profile a637b596-0987-4149-a216-1ec6dcff8c5b"}
```
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
