### PR TITLE
removing snapshot name constraint

### DIFF
--- a/contrib/drivers/filesharedrivers/nfs/nfs.go
+++ b/contrib/drivers/filesharedrivers/nfs/nfs.go
@@ -285,7 +285,7 @@ func (d *Driver) CreateFileShareSnapshot(opt *pb.CreateFileShareSnapshotOpts) (*
 		log.Error(err)
 		return nil, err
 	}
-	snapName := opt.GetName()
+	snapName := snapshotPrefix + opt.GetName()
 	fields := strings.Split(lvPath, "/")
 
 	vg, sourceLvName := fields[2], fields[3]

--- a/install/devsds/lib/lvm.sh
+++ b/install/devsds/lib/lvm.sh
@@ -51,6 +51,10 @@ osds::lvm::pkg_install(){
     sudo apt-get install -y lvm2 tgt open-iscsi ibverbs-utils
 }
 
+osds::nfs::pkg_install(){
+    sudo apt-get install -y nfs-kernel-server
+}
+
 osds::lvm::pkg_uninstall(){
     sudo apt-get purge -y lvm2 tgt open-iscsi ibvverbs-utils
 }
@@ -361,6 +365,7 @@ osds::lvm::install() {
 
     # Install lvm relative packages.
     osds::lvm::pkg_install
+    osds::nfs::pkg_install
     osds::lvm::create_volume_group_for_file $fvg $size
     osds::lvm::create_volume_group $vg $size
 

--- a/pkg/api/util/db.go
+++ b/pkg/api/util/db.go
@@ -185,12 +185,6 @@ func CreateFileShareSnapshotDBEntry(ctx *c.Context, in *model.FileShareSnapshotS
 		in.CreatedAt = time.Now().Format(constants.TimeFormat)
 	}
 
-	//validate the snapshot name
-	if strings.HasPrefix(in.Name, "snapshot") {
-		errMsg := fmt.Sprintf("Names starting 'snapshot' are reserved. Please choose a different snapshot name.")
-		log.Error(errMsg)
-		return nil, errors.New(errMsg)
-	}
 	in.Status = model.FileShareSnapCreating
 	in.Metadata = fshare.Metadata
 	return db.C.CreateFileShareSnapshot(ctx, in)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Removing the snapshot name constraint for fileshare snapshot creation

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
