### PR TITLE
Add locks to avoid concurrency deletion conflicts. 

### DIFF
--- a/pkg/dock/dock.go
+++ b/pkg/dock/dock.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"sync"
 
 	log "github.com/golang/glog"
 	"github.com/opensds/opensds/contrib/connector"
@@ -44,7 +45,8 @@ import (
 
 // dockServer is used to implement pb.DockServer
 type dockServer struct {
-	Port string
+	mutex sync.Mutex
+	Port  string
 	// Discoverer represents the mechanism of DockHub discovering the storage
 	// capabilities from different backends.
 	Discoverer discovery.DockDiscoverer
@@ -134,9 +136,13 @@ func (ds *dockServer) CreateVolume(ctx context.Context, opt *pb.CreateVolumeOpts
 
 // DeleteVolume implements pb.DockServer.DeleteVolume
 func (ds *dockServer) DeleteVolume(ctx context.Context, opt *pb.DeleteVolumeOpts) (*pb.GenericResponse, error) {
+	ds.mutex.Lock()
 	// Get the storage drivers and do some initializations.
 	ds.Driver = drivers.Init(opt.GetDriverName())
-	defer drivers.Clean(ds.Driver)
+	defer func() {
+		drivers.Clean(ds.Driver)
+		ds.mutex.Unlock()
+	}()
 
 	log.Info("Dock server receive delete volume request, vr =", opt)
 
@@ -200,10 +206,13 @@ func (ds *dockServer) CreateVolumeAttachment(ctx context.Context, opt *pb.Create
 
 // DeleteVolumeAttachment implements pb.DockServer.DeleteVolumeAttachment
 func (ds *dockServer) DeleteVolumeAttachment(ctx context.Context, opt *pb.DeleteVolumeAttachmentOpts) (*pb.GenericResponse, error) {
+	ds.mutex.Lock()
 	// Get the storage drivers and do some initializations.
 	ds.Driver = drivers.Init(opt.GetDriverName())
-	defer drivers.Clean(ds.Driver)
-
+	defer func() {
+		drivers.Clean(ds.Driver)
+		ds.mutex.Unlock()
+	}()
 	log.Info("Dock server receive delete volume attachment request, vr =", opt)
 
 	if err := ds.Driver.TerminateConnection(opt); err != nil {
@@ -233,10 +242,13 @@ func (ds *dockServer) CreateVolumeSnapshot(ctx context.Context, opt *pb.CreateVo
 
 // DeleteVolumeSnapshot implements pb.DockServer.DeleteVolumeSnapshot
 func (ds *dockServer) DeleteVolumeSnapshot(ctx context.Context, opt *pb.DeleteVolumeSnapshotOpts) (*pb.GenericResponse, error) {
+	ds.mutex.Lock()
 	// Get the storage drivers and do some initializations.
 	ds.Driver = drivers.Init(opt.GetDriverName())
-	defer drivers.Clean(ds.Driver)
-
+	defer func() {
+		drivers.Clean(ds.Driver)
+		ds.mutex.Unlock()
+	}()
 	log.Info("Dock server receive delete volume snapshot request, vr =", opt)
 
 	if err := ds.Driver.DeleteSnapshot(opt); err != nil {
@@ -315,9 +327,13 @@ func (ds *dockServer) CreateReplication(ctx context.Context, opt *pb.CreateRepli
 }
 
 func (ds *dockServer) DeleteReplication(ctx context.Context, opt *pb.DeleteReplicationOpts) (*pb.GenericResponse, error) {
+	ds.mutex.Lock()
 	// Get the storage replication drivers and do some initializations.
 	driver, _ := drivers.InitReplicationDriver(opt.GetDriverName())
-	defer drivers.CleanReplicationDriver(driver)
+	defer func() {
+		drivers.CleanReplicationDriver(driver)
+		ds.mutex.Unlock()
+	}()
 
 	log.Info("Dock server receive delete replication request, vr =", opt)
 
@@ -426,9 +442,13 @@ func (ds *dockServer) UpdateVolumeGroup(ctx context.Context, opt *pb.UpdateVolum
 }
 
 func (ds *dockServer) DeleteVolumeGroup(ctx context.Context, opt *pb.DeleteVolumeGroupOpts) (*pb.GenericResponse, error) {
+	ds.mutex.Lock()
 	// Get the storage drivers and do some initializations.
 	ds.Driver = drivers.Init(opt.GetDriverName())
-	defer drivers.Clean(ds.Driver)
+	defer func() {
+		drivers.Clean(ds.Driver)
+		ds.mutex.Unlock()
+	}()
 
 	log.Info("Dock server receive delete volume group request, vr =", opt)
 
@@ -506,9 +526,13 @@ func (ds *dockServer) CreateFileShareAcl(ctx context.Context, opt *pb.CreateFile
 
 // DeleteFileShareAcl implements pb.DockServer.DeleteFileShare
 func (ds *dockServer) DeleteFileShareAcl(ctx context.Context, opt *pb.DeleteFileShareAclOpts) (*pb.GenericResponse, error) {
+	ds.mutex.Lock()
 	// Get the storage drivers and do some initializations.
 	ds.FileShareDriver = filesharedrivers.Init(opt.GetDriverName())
-	defer filesharedrivers.Clean(ds.FileShareDriver)
+	defer func() {
+		filesharedrivers.Clean(ds.FileShareDriver)
+		ds.mutex.Unlock()
+	}()
 
 	log.Info("dock server receive delete file share acl request, vr =", opt)
 
@@ -541,10 +565,13 @@ func (ds *dockServer) CreateFileShare(ctx context.Context, opt *pb.CreateFileSha
 
 // DeleteFileShare implements pb.DockServer.DeleteFileShare
 func (ds *dockServer) DeleteFileShare(ctx context.Context, opt *pb.DeleteFileShareOpts) (*pb.GenericResponse, error) {
-
+	ds.mutex.Lock()
 	// Get the storage drivers and do some initializations.
 	ds.FileShareDriver = filesharedrivers.Init(opt.GetDriverName())
-	defer filesharedrivers.Clean(ds.FileShareDriver)
+	defer func() {
+		filesharedrivers.Clean(ds.FileShareDriver)
+		ds.mutex.Unlock()
+	}()
 
 	log.Info("Dock server receive delete file share request, vr =", opt)
 
@@ -575,9 +602,13 @@ func (ds *dockServer) CreateFileShareSnapshot(ctx context.Context, opt *pb.Creat
 }
 
 func (ds *dockServer) DeleteFileShareSnapshot(ctx context.Context, opt *pb.DeleteFileShareSnapshotOpts) (*pb.GenericResponse, error) {
+	ds.mutex.Lock()
 	// Get the storage drivers and do some initializations.
 	ds.FileShareDriver = filesharedrivers.Init(opt.GetDriverName())
-	defer filesharedrivers.Clean(ds.FileShareDriver)
+	defer func() {
+		filesharedrivers.Clean(ds.FileShareDriver)
+		ds.mutex.Unlock()
+	}()
 
 	log.Info("Dock server receive delete file share snapshot request, vr =", opt)
 

--- a/pkg/model/proto/response.go
+++ b/pkg/model/proto/response.go
@@ -28,7 +28,10 @@ func GenericResponseResult(resMsg interface{}) *GenericResponse {
 		msg = resMsg.(string)
 		break
 	default:
-		msgJSON, _ := json.Marshal(resMsg)
+		msgJSON, err := json.Marshal(resMsg)
+		if err != nil {
+			fmt.Printf("unmarshal error in response result: %v", err)
+		}
 		msg = string(msgJSON)
 	}
 
@@ -39,7 +42,6 @@ func GenericResponseResult(resMsg interface{}) *GenericResponse {
 			},
 		},
 	}
-
 }
 
 func GenericResponseError(errMsg interface{}) *GenericResponse {

--- a/pkg/model/proto/response_test.go
+++ b/pkg/model/proto/response_test.go
@@ -69,4 +69,17 @@ func TestGenericResponseResult(t *testing.T) {
 		result := GenericResponseResult(resMsg)
 		assertTestResult(t, result, expected)
 	})
+
+	t.Run("nil pointer", func(t *testing.T) {
+		expected := &GenericResponse{
+			Reply: &GenericResponse_Result_{
+				Result: &GenericResponse_Result{
+					Message: "",
+				},
+			},
+		}
+
+		result := GenericResponseResult(nil)
+		assertTestResult(t, result, expected)
+	})
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Concurrency conflict occurs when multiple delete requests are sent simultaneously. So add locks to avoid concurrency conflicts.
```
go run  -race github.com/opensds/opensds/cmd/osdsdock -alsologtostderr
==================
WARNING: DATA RACE
Write at 0x00c000156400 by goroutine 44:
  github.com/opensds/opensds/pkg/dock.(*dockServer).DeleteFileShare()
      /root/gopath/src/github.com/opensds/opensds/pkg/dock/dock.go:546 +0xa9
  github.com/opensds/opensds/pkg/model/proto._FileShareDock_DeleteFileShare_Handler()
      /root/gopath/src/github.com/opensds/opensds/pkg/model/proto/model.pb.go:5713 +0x2fc
  github.com/opensds/opensds/vendor/google.golang.org/grpc.(*Server).processUnaryRPC()
      /root/gopath/src/github.com/opensds/opensds/vendor/google.golang.org/grpc/server.go:966 +0x8d3
  github.com/opensds/opensds/vendor/google.golang.org/grpc.(*Server).handleStream()
      /root/gopath/src/github.com/opensds/opensds/vendor/google.golang.org/grpc/server.go:1245 +0x136f
  github.com/opensds/opensds/vendor/google.golang.org/grpc.(*Server).serveStreams.func1.1()
      /root/gopath/src/github.com/opensds/opensds/vendor/google.golang.org/grpc/server.go:685 +0xac

Previous read at 0x00c000156400 by goroutine 51:
  github.com/opensds/opensds/pkg/dock.(*dockServer).DeleteFileShare()
      /root/gopath/src/github.com/opensds/opensds/pkg/dock/dock.go:551 +0x184
  github.com/opensds/opensds/pkg/model/proto._FileShareDock_DeleteFileShare_Handler()
      /root/gopath/src/github.com/opensds/opensds/pkg/model/proto/model.pb.go:5713 +0x2fc
  github.com/opensds/opensds/vendor/google.golang.org/grpc.(*Server).processUnaryRPC()
      /root/gopath/src/github.com/opensds/opensds/vendor/google.golang.org/grpc/server.go:966 +0x8d3
  github.com/opensds/opensds/vendor/google.golang.org/grpc.(*Server).handleStream()
      /root/gopath/src/github.com/opensds/opensds/vendor/google.golang.org/grpc/server.go:1245 +0x136f
  github.com/opensds/opensds/vendor/google.golang.org/grpc.(*Server).serveStreams.func1.1()
      /root/gopath/src/github.com/opensds/opensds/vendor/google.golang.org/grpc/server.go:685 +0xac


```