### PR TITLE
Snapshot name existence check - Fix #931

### DIFF
--- a/pkg/api/util/db.go
+++ b/pkg/api/util/db.go
@@ -210,6 +210,22 @@ func CreateFileShareSnapshotDBEntry(ctx *c.Context, in *model.FileShareSnapshotS
 		return nil, errors.New(errMsg)
 	}
 
+	// Check existence of fileshare snapshot name #931
+	filesnaps, err := db.C.ListFileShareSnapshots(ctx)
+	if err != nil {
+		errMsg := fmt.Sprintf("get list of fileshare snapshot failed: %s", err.Error())
+		log.Error(errMsg)
+		return nil, errors.New(errMsg)
+	} else {
+		for _, filesnap := range filesnaps {
+			if filesnap.Name == in.Name {
+				errMsg := fmt.Sprintf("file share snapshot name already exists")
+				log.Error(errMsg)
+				return nil, errors.New(errMsg)
+			}
+		}
+	}
+
 	if in.Id == "" {
 		in.Id = uuid.NewV4().String()
 	}

--- a/pkg/api/util/db_test.go
+++ b/pkg/api/util/db_test.go
@@ -401,3 +401,51 @@ func TestDeleteVolumeSnapshotDBEntry(t *testing.T) {
 		}
 	})
 }
+
+func TestCreateFileShareSnapshotDBEntry(t *testing.T) {
+	var fileshare = &model.FileShareSpec{
+		BaseModel: &model.BaseModel{
+			Id: "bd5b12a8-a101-11e7-941e-d77981b584d8",
+		},
+		Status: "available",
+	}
+	var req = &model.FileShareSnapshotSpec{
+		BaseModel: &model.BaseModel{
+			Id: "3769855c-a102-11e7-b772-17b880d2f537",
+		},
+		Name:        "sample-snapshot-01",
+		Description: "This is the first sample snapshot for testing",
+		Status:      "available",
+		ShareSize:  int64(1),
+		FileShareId: "bd5b12a8-a101-11e7-941e-d77981b584d8",
+		ProfileId:   "1106b972-66ef-11e7-b172-db03f3689c9c",
+	}
+
+	var sampleSnapshots = []*model.FileShareSnapshotSpec{&SampleShareSnapshots[0]}
+	t.Run("-ve test case - snapshot name already exists", func(t *testing.T) {
+		mockClient := new(dbtest.Client)
+		mockClient.On("GetFileShare", context.NewAdminContext(), "bd5b12a8-a101-11e7-941e-d77981b584d8").Return(fileshare, nil)
+		mockClient.On("ListFileShareSnapshots", context.NewAdminContext()).Return(sampleSnapshots, nil)
+		db.C = mockClient
+
+		_, err := CreateFileShareSnapshotDBEntry(context.NewAdminContext(), req)
+		expectedError := "file share snapshot name already exists"
+		assertTestResult(t, err.Error(), expectedError)
+	})
+
+	t.Run("test +ve", func(t *testing.T) {
+		mockClient := new(dbtest.Client)
+		mockClient.On("GetFileShare", context.NewAdminContext(), "bd5b12a8-a101-11e7-941e-d77981b584d8").Return(fileshare, nil)
+		mockClient.On("ListFileShareSnapshots", context.NewAdminContext()).Return(nil, nil)
+		mockClient.On("CreateFileShareSnapshot", context.NewAdminContext(), req).Return(&SampleShareSnapshots[0], nil)
+		db.C = mockClient
+
+		var expected = &SampleShareSnapshots[0]
+		result, err := CreateFileShareSnapshotDBEntry(context.NewAdminContext(), req)
+		if err != nil {
+			t.Errorf("failed to create fileshare snapshot, err is %v\n", err)
+		}
+		assertTestResult(t, result, expected)
+	})
+
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Snapshot name existence check - Duplication of file share snapshot name is not allowed.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
