### PR TITLE
File Share ACL create and delete services updating file share status are corrected - Fix #930

### DIFF
--- a/pkg/api/util/db.go
+++ b/pkg/api/util/db.go
@@ -109,19 +109,36 @@ func CreateFileShareAclDBEntry(ctx *c.Context, in *model.FileShareAclSpec) (*mod
 		return nil, errors.New(errMsg)
 	}
 
-	// Store the fileshare meadata into database.
 	return db.C.CreateFileShareAcl(ctx, in)
 }
 
 func DeleteFileShareAclDBEntry(ctx *c.Context, in *model.FileShareAclSpec) error {
-	// If fileshare id is invalid, it would mean that fileshare snapshot
+	// If fileshare id is invalid, it would mean that fileshare acl
 	// creation failed before the create method in storage driver was
 	// called, and delete its db entry directly.
-	if _, err := db.C.GetFileShare(ctx, in.FileShareId); err != nil {
+	validStatus := []string{model.FileShareAclAvailable, model.FileShareAclError,
+		model.FileShareAclErrorDeleting}
+	if !utils.Contained(in.Status, validStatus) {
+		errMsg := fmt.Sprintf("only the file share acl with the status available, error, error_deleting can be deleted, the fileshare status is %s", in.Status)
+		log.Error(errMsg)
+		return errors.New(errMsg)
+	}
+
+	// If fileshare id is invalid, it would mean that file share acl creation failed before the create method
+	// in storage driver was called, and delete its db entry directly.
+	_, err := db.C.GetFileShare(ctx, in.FileShareId)
+	if err != nil {
 		if err := db.C.DeleteFileShareAcl(ctx, in.Id); err != nil {
-			log.Error("when delete fileshare acl in db:", err)
+			log.Error("failed delete fileshare acl in db:", err)
 			return err
 		}
+		return nil
+	}
+
+	in.Status = model.FileShareAclDeleting
+	_, err = db.C.UpdateFileShareAcl(ctx, in)
+	if err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -234,6 +234,11 @@ func UpdateFileShareSnapshotStatus(ctx *c.Context, client Client, snapID, status
 	return client.UpdateStatus(ctx, snap, status)
 }
 
+func UpdateFileShareAclStatus(ctx *c.Context, client Client, fileID, status string) error {
+	file, _ := client.GetFileShareAcl(ctx, fileID)
+	return client.UpdateStatus(ctx, file, status)
+}
+
 func UpdateVolumeStatus(ctx *c.Context, client Client, volID, status string) error {
 	vol, _ := client.GetVolume(ctx, volID)
 	return client.UpdateStatus(ctx, vol, status)

--- a/pkg/model/fileshare.go
+++ b/pkg/model/fileshare.go
@@ -39,6 +39,10 @@ type FileShareAclSpec struct {
 	// The description of the fileshare acl.
 	Description string `json:"description,omitempty"`
 
+	// The status of the fileshareacl.
+	// One of: "available", "error" etc.
+	Status string `json:"status,omitempty"`
+
 	// The uuid of the profile which the fileshare belongs to.
 	ProfileId string `json:"profileId,omitempty"`
 

--- a/pkg/model/status.go
+++ b/pkg/model/status.go
@@ -33,6 +33,15 @@ const (
 	FileShareSnapErrorDeleting = "errorDeleting"
 )
 
+// fileshare acl status
+const (
+	FileShareAclAvailable     = "available"
+	FileShareAclDeleting      = "deleting"
+	FileShareAclError         = "error"
+	FileShareAclErrorDeleting = "errorDeleting"
+	FileShareAclInUse         = "in_Use"
+)
+
 // volume status
 const (
 	VolumeCreating       = "creating"

--- a/testutils/collection/data.go
+++ b/testutils/collection/data.go
@@ -244,7 +244,30 @@ var (
 			Description: "This is a sample Acl for testing",
 		},
 	}
-
+	SampleSharesAcl = []model.FileShareAclSpec{
+		{
+			BaseModel: &model.BaseModel{
+				Id: "d2975ebe-d82c-430f-b28e-f373746a71ca",
+			},
+			Status: "available",
+			FileShareId: "bd5b12a8-a101-11e7-941e-d77981b584d8",
+			ProfileId: "3769855c-a102-11e7-b772-17b880d2f537",
+			Type: "ip",
+			AccessTo: "10.21.23.10",
+			AccessCapability:[]string{"Read", "Write"},
+		},
+		{
+			BaseModel: &model.BaseModel{
+				Id: "1e643aca-4922-4b1a-bb98-4245054aeff4",
+			},
+			Status: "available",
+			FileShareId: "bd5b12a8-a101-11e7-941e-d77981b584d8",
+			ProfileId: "3769855c-a102-11e7-b772-17b880d2f537",
+			Type: "ip",
+			AccessTo: "101.21.23.10",
+			AccessCapability:[]string{"Read"},
+		},
+	}
 	SampleFileShareSnapshots = []model.FileShareSnapshotSpec{
 		{
 			BaseModel: &model.BaseModel{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Problem statement:
==============
Create file share acl code was updating file share status when it fails to create and deletion of acl as well.
There was not status field in Fileshareaclspec to update it's status when it is successful or fails.
So #794 PR is updating fileshare status when acl creation fails, it was causing fatal error so issue has been raised #930 

Solution/Fix:
==========
Added  status field in Fileshareaclspec to tract it's status of creation and failure.
Whenever ACL creation fails to create, it will be update file share acl status.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
