### PR TITLE
Fix-#924 fileshare description validation

### DIFF
--- a/pkg/api/util/db.go
+++ b/pkg/api/util/db.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"regexp"
 	"strings"
 	"time"
 
@@ -163,6 +164,20 @@ func CreateFileShareDBEntry(ctx *c.Context, in *model.FileShareSpec) (*model.Fil
 		log.Error(errMsg)
 		return nil, errors.New(errMsg)
 	}
+
+	// validate the description
+	reg, err := regexp.Compile("[^a-zA-Z0-9 ]+")
+	if err != nil {
+		errMsg := fmt.Sprintf("regex compilation for file share description validation failed")
+		log.Error(errMsg)
+		return nil, errors.New(errMsg)
+	}
+	if reg.MatchString(in.Description) {
+		errMsg := fmt.Sprintf("invalid fileshare description and it has some special characters")
+		log.Error(errMsg)
+		return nil, errors.New(errMsg)
+	}
+
 	in.UserId = ctx.UserId
 	in.Status = model.FileShareCreating
 	// Store the fileshare meadata into database.

--- a/pkg/api/util/db_test.go
+++ b/pkg/api/util/db_test.go
@@ -17,6 +17,7 @@ package util
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 	"testing"
 
 	"github.com/opensds/opensds/pkg/context"
@@ -474,4 +475,83 @@ func TestCreateFileShareSnapshotDBEntry(t *testing.T) {
 		assertTestResult(t, result, expected)
 	})
 
+}
+
+func TestCreateFileShareDBEntry(t *testing.T) {
+	var in = &model.FileShareSpec{
+		BaseModel:   &model.BaseModel{},
+		Name:        "sample-fileshare-01",
+		Description: "This is a sample fileshare for testing",
+		Size:        int64(1),
+		ProfileId:   "b3585ebe-c42c-120g-b28e-f373746a71ca",
+		Status:      model.FileShareCreating,
+	}
+
+	t.Run("Everything should work well", func(t *testing.T) {
+		mockClient := new(dbtest.Client)
+		mockClient.On("CreateFileShare", context.NewAdminContext(), in).Return(&SampleFileShares[0], nil)
+		db.C = mockClient
+
+		var expected = &SampleFileShares[0]
+		result, err := CreateFileShareDBEntry(context.NewAdminContext(), in)
+		if err != nil {
+			t.Errorf("failed to create fileshare err is %v\n", err)
+		}
+		assertTestResult(t, result, expected)
+	})
+
+	t.Run("The size of fileshare created should be greater than zero", func(t *testing.T) {
+		in.Size = int64(-2)
+		mockClient := new(dbtest.Client)
+		mockClient.On("CreateFileShare", context.NewAdminContext(), in).Return(&SampleFileShares[0], nil)
+		db.C = mockClient
+
+		_, err := CreateFileShareDBEntry(context.NewAdminContext(), in)
+		expectedError := fmt.Sprintf("invalid fileshare size: %d", in.Size)
+		assertTestResult(t, err.Error(), expectedError)
+	})
+
+	t.Run("The profile id should not be empty", func(t *testing.T) {
+		in.ProfileId = ""
+		mockClient := new(dbtest.Client)
+		mockClient.On("CreateFileShare", context.NewAdminContext(), in).Return(&SampleFileShares[0], nil)
+		db.C = mockClient
+
+		_, err := CreateFileShareDBEntry(context.NewAdminContext(), in)
+		expectedError := "profile id can not be empty when creating fileshare in db!"
+		assertTestResult(t, err.Error(), expectedError)
+	})
+
+	t.Run("Empty file share name is allowed", func(t *testing.T) {
+		in.Size, in.Name, in.ProfileId = int64(1),"", "b3585ebe-c42c-120g-b28e-f373746a71ca"
+		mockClient := new(dbtest.Client)
+		mockClient.On("CreateFileShare", context.NewAdminContext(), in).Return(&SampleFileShares[0], nil)
+		db.C = mockClient
+
+		_, err := CreateFileShareDBEntry(context.NewAdminContext(), in)
+		expectedError := "empty fileshare name is not allowed. Please give valid name."
+		assertTestResult(t, err.Error(), expectedError)
+	})
+
+	t.Run("File share name length more than 128 characters are not allowed", func(t *testing.T) {
+		in.Size, in.Name, in.ProfileId = int64(1),"kjxdpvfuenecpyhbxdumwibipjkigcjykabuhghjghjgjgjgjgjghhkkkkkkkkkkkkkkklsccdesnkgxnjnhfjusigceorogdgjlyciemscgvncerucokfekdiviuyplbly", "b3585ebe-c42c-120g-b28e-f373746a71ca"
+		mockClient := new(dbtest.Client)
+		mockClient.On("CreateFileShare", context.NewAdminContext(), in).Return(&SampleFileShares[0], nil)
+		db.C = mockClient
+
+		_, err := CreateFileShareDBEntry(context.NewAdminContext(), in)
+		expectedError := "fileshare name length should not more than 128 characters. current length is : "+strconv.Itoa(len(in.Name))
+		assertTestResult(t, err.Error(), expectedError)
+	})
+
+	t.Run("Special characters in file share description are not allowed", func(t *testing.T) {
+		in.Size, in.Name, in.ProfileId, in.Description = int64(1),"sample-fileshare-01", "b3585ebe-c42c-120g-b28e-f373746a71ca", "#FileShare Code!$! test"
+		mockClient := new(dbtest.Client)
+		mockClient.On("CreateFileShare", context.NewAdminContext(), in).Return(&SampleFileShares[0], nil)
+		db.C = mockClient
+
+		_, err := CreateFileShareDBEntry(context.NewAdminContext(), in)
+		expectedError := "invalid fileshare description and it has some special characters"
+		assertTestResult(t, err.Error(), expectedError)
+	})
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
File share description validation
If it has any special character then it not considered as valid file share description

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
