### PR TITLE
Fix null pointer error.

### DIFF
--- a/contrib/drivers/huawei/fusionstorage/fusionstorage.go
+++ b/contrib/drivers/huawei/fusionstorage/fusionstorage.go
@@ -55,6 +55,9 @@ func (d *Driver) Setup() error {
 }
 
 func (d *Driver) Unset() error {
+	if d.Client == nil {
+		return errors.New("cannot get client")
+	}
 	return d.Client.logout()
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
When the client cannot be obtained, calling the logout function will throw a null pointer error.