### PR TITLE
driver: introduce chubaofs fileshare driver

### DIFF
--- a/contrib/drivers/filesharedrivers/chubaofs/chubaofs.go
+++ b/contrib/drivers/filesharedrivers/chubaofs/chubaofs.go
@@ -1,0 +1,249 @@
+// Copyright (c) 2019 The OpenSDS Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chubaofs
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path"
+
+	log "github.com/golang/glog"
+	. "github.com/opensds/opensds/contrib/drivers/utils/config"
+	. "github.com/opensds/opensds/pkg/model"
+	pb "github.com/opensds/opensds/pkg/model/proto"
+	"github.com/opensds/opensds/pkg/utils/config"
+	uuid "github.com/satori/go.uuid"
+)
+
+const (
+	DefaultConfPath = "/etc/opensds/driver/chubaofs.yaml"
+	NamePrefix      = "chubaofs"
+)
+
+const (
+	KMountPoint = "mountPoint"
+	KVolumeName = "volName"
+	KMasterAddr = "masterAddr"
+	KLogDir     = "logDir"
+	KWarnLogDir = "warnLogDir"
+	KLogLevel   = "logLevel"
+	KOwner      = "owner"
+	KProfPort   = "profPort"
+)
+
+const (
+	KClientPath = "clientPath"
+)
+
+const (
+	defaultLogLevel = "error"
+	defaultOwner    = "chubaofs"
+	defaultProfPort = "10094"
+
+	defaultVolumeCapLimit int64 = 1000000
+)
+
+const (
+	clientConfigFileName = "client.json"
+	clientCmdName        = "cfs-client"
+)
+
+type ClusterInfo struct {
+	Name           string   `yaml:"name"`
+	MasterAddr     []string `yaml:"masterAddr"`
+	VolumeCapLimit int64    `yaml:"volumeCapLimit"`
+}
+
+type RuntimeEnv struct {
+	MntPoint   string `yaml:"mntPoint"`
+	ClientPath string `yaml:"clientPath"`
+	LogLevel   string `yaml:"logLevel"`
+	Owner      string `yaml:"owner"`
+	ProfPort   string `yaml:"profPort"`
+}
+
+type Config struct {
+	ClusterInfo `yaml:"clusterInfo"`
+	RuntimeEnv  `yaml:"runtimeEnv"`
+
+	Pool map[string]PoolProperties `yaml:"pool,flow"`
+}
+
+type Driver struct {
+	conf *Config
+}
+
+func (d *Driver) Setup() error {
+	conf := &Config{}
+	path := config.CONF.OsdsDock.Backends.Chubaofs.ConfigPath
+	if "" == path {
+		path = DefaultConfPath
+	}
+
+	if _, err := Parse(conf, path); err != nil {
+		return err
+	}
+
+	if conf.MntPoint == "" || conf.ClientPath == "" {
+		return errors.New(fmt.Sprintf("chubaofs: lack of necessary config, mntPoint(%v) clientPath(%v)", conf.MntPoint, conf.ClientPath))
+	}
+
+	if conf.VolumeCapLimit <= 0 {
+		conf.VolumeCapLimit = defaultVolumeCapLimit
+	}
+
+	d.conf = conf
+	return nil
+}
+
+func (d *Driver) Unset() error {
+	return nil
+}
+
+func (d *Driver) CreateFileShare(opt *pb.CreateFileShareOpts) (fshare *FileShareSpec, err error) {
+	log.Info("CreateFileShare ...")
+
+	volName := opt.GetId()
+	volSize := opt.GetSize()
+
+	configFiles, fsMntPoints, owner, err := prepareConfigFiles(d, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	/*
+	 * Only the master raft leader can repsonse to create volume requests.
+	 */
+	leader, err := getClusterInfo(d.conf.MasterAddr[0])
+	if err != nil {
+		return nil, err
+	}
+
+	err = createOrDeleteVolume(createVolumeRequest, leader, volName, owner, volSize)
+	if err != nil {
+		return nil, err
+	}
+
+	err = doMount(clientCmdName, configFiles)
+	if err != nil {
+		doUmount(fsMntPoints)
+		createOrDeleteVolume(deleteVolumeRequest, leader, volName, owner, 0)
+		return nil, err
+	}
+
+	log.Infof("Start client daemon successful: volume name: %v", volName)
+
+	fshare = &FileShareSpec{
+		BaseModel: &BaseModel{
+			Id: opt.GetId(),
+		},
+		Name:             opt.GetName(),
+		Size:             opt.GetSize(),
+		Description:      opt.GetDescription(),
+		AvailabilityZone: opt.GetAvailabilityZone(),
+		PoolId:           opt.GetPoolId(),
+		ExportLocations:  fsMntPoints,
+		Metadata: map[string]string{
+			KVolumeName: volName,
+			KClientPath: d.conf.ClientPath,
+			KOwner:      owner,
+		},
+	}
+
+	return fshare, nil
+}
+
+func (d *Driver) DeleteFileShare(opts *pb.DeleteFileShareOpts) error {
+	volName := opts.GetMetadata()[KVolumeName]
+	clientPath := opts.GetMetadata()[KClientPath]
+	owner := opts.GetMetadata()[KOwner]
+	fsMntPoints := make([]string, 0)
+	fsMntPoints = append(fsMntPoints, opts.ExportLocations...)
+
+	/*
+	 * Umount export locations
+	 */
+	err := doUmount(fsMntPoints)
+	if err != nil {
+		return err
+	}
+
+	/*
+	 * Remove generated mount points dir
+	 */
+	for _, mnt := range fsMntPoints {
+		err = os.RemoveAll(mnt)
+		if err != nil {
+			return errors.New(fmt.Sprintf("chubaofs: failed to remove export locations, err: %v", err))
+		}
+	}
+
+	/*
+	 * Remove generated client runtime path
+	 */
+	err = os.RemoveAll(path.Join(clientPath, volName))
+	if err != nil {
+		return errors.New(fmt.Sprintf("chubaofs: failed to remove client path %v , volume name: %v , err: %v", clientPath, volName, err))
+	}
+
+	/*
+	 * Only the master raft leader can repsonse to delete volume requests.
+	 */
+	leader, err := getClusterInfo(d.conf.MasterAddr[0])
+	if err != nil {
+		return err
+	}
+	err = createOrDeleteVolume(deleteVolumeRequest, leader, volName, owner, 0)
+	return err
+}
+
+func (d *Driver) CreateFileShareSnapshot(opts *pb.CreateFileShareSnapshotOpts) (*FileShareSnapshotSpec, error) {
+	return nil, &NotImplementError{"CreateFileShareSnapshot not implemented yet"}
+}
+
+func (d *Driver) DeleteFileShareSnapshot(opts *pb.DeleteFileShareSnapshotOpts) error {
+	return &NotImplementError{"DeleteFileShareSnapshot not implemented yet"}
+}
+
+func (d *Driver) CreateFileShareAcl(opts *pb.CreateFileShareAclOpts) (*FileShareAclSpec, error) {
+	return nil, &NotImplementError{"CreateFileShareAcl not implemented yet"}
+}
+
+func (d *Driver) DeleteFileShareAcl(opts *pb.DeleteFileShareAclOpts) error {
+	return &NotImplementError{"DeleteFileShareAcl not implemented yet"}
+}
+
+func (d *Driver) ListPools() ([]*StoragePoolSpec, error) {
+	pools := make([]*StoragePoolSpec, 0)
+	for name, prop := range d.conf.Pool {
+		pool := &StoragePoolSpec{
+			BaseModel: &BaseModel{
+				Id: uuid.NewV5(uuid.NamespaceOID, name).String(),
+			},
+			Name:             name,
+			TotalCapacity:    d.conf.VolumeCapLimit,
+			FreeCapacity:     d.conf.VolumeCapLimit,
+			StorageType:      prop.StorageType,
+			Extras:           prop.Extras,
+			AvailabilityZone: prop.AvailabilityZone,
+		}
+		if pool.AvailabilityZone == "" {
+			pool.AvailabilityZone = "default"
+		}
+		pools = append(pools, pool)
+	}
+	return pools, nil
+}

--- a/contrib/drivers/filesharedrivers/chubaofs/util.go
+++ b/contrib/drivers/filesharedrivers/chubaofs/util.go
@@ -1,0 +1,343 @@
+package chubaofs
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	log "github.com/golang/glog"
+	pb "github.com/opensds/opensds/pkg/model/proto"
+)
+
+type RequestType int
+
+func (t RequestType) String() string {
+	switch t {
+	case createVolumeRequest:
+		return "CreateVolume"
+	case deleteVolumeRequest:
+		return "DeleteVolume"
+	default:
+	}
+	return "N/A"
+}
+
+const (
+	createVolumeRequest RequestType = iota
+	deleteVolumeRequest
+)
+
+type clusterInfoResponseData struct {
+	LeaderAddr string `json:"LeaderAddr"`
+}
+
+type clusterInfoResponse struct {
+	Code int                      `json:"code"`
+	Msg  string                   `json:"msg"`
+	Data *clusterInfoResponseData `json:"data"`
+}
+
+// Create and Delete Volume Response
+type generalVolumeResponse struct {
+	Code int    `json:"code"`
+	Msg  string `json:"msg"`
+	Data string `json:"data"`
+}
+
+/*
+ * This functions sends http request to the on-premise cluster to
+ * get cluster info.
+ */
+func getClusterInfo(host string) (string, error) {
+	url := "http://" + host + "/admin/getCluster"
+	log.Infof("chubaofs: GetClusterInfo(%v)", url)
+
+	httpResp, err := http.Get(url)
+	if err != nil {
+		log.Errorf("chubaofs: failed to GetClusterInfo, url(%v) err(%v)", url, err)
+		return "", err
+	}
+	defer httpResp.Body.Close()
+
+	body, err := ioutil.ReadAll(httpResp.Body)
+	if err != nil {
+		log.Errorf("chubaofs: failed to read response, url(%v) err(%v)", url, err)
+		return "", err
+	}
+
+	resp := &clusterInfoResponse{}
+	if err = json.Unmarshal(body, resp); err != nil {
+		errmsg := fmt.Sprintf("chubaofs: getClusterInf failed to unmarshal, bodyLen(%d) err(%v)", len(body), err)
+		log.Error(errmsg)
+		return "", errors.New(errmsg)
+	}
+
+	log.Infof("chubaofs: GetClusterInfo, url(%v), resp(%v)", url, resp)
+
+	if resp.Code != 0 {
+		errmsg := fmt.Sprintf("chubaofs: GetClusterInfo code NOK, url(%v) code(%v) msg(%v)", url, resp.Code, resp.Msg)
+		log.Error(errmsg)
+		return "", errors.New(errmsg)
+	}
+
+	if resp.Data == nil {
+		errmsg := fmt.Sprintf("chubaofs: GetClusterInfo nil data, url(%v) code(%v) msg(%v)", url, resp.Code, resp.Msg)
+		log.Error(errmsg)
+		return "", errors.New(errmsg)
+	}
+
+	return resp.Data.LeaderAddr, nil
+}
+
+/*
+ * This function sends http request to the on-premise cluster to create
+ * or delete a volume according to request type.
+ */
+func createOrDeleteVolume(req RequestType, leader, name, owner string, size int64) error {
+	var url string
+
+	switch req {
+	case createVolumeRequest:
+		sizeInGB := size
+		url = fmt.Sprintf("http://%s/admin/createVol?name=%s&capacity=%v&owner=%v", leader, name, sizeInGB, owner)
+	case deleteVolumeRequest:
+		key := md5.New()
+		if _, err := key.Write([]byte(owner)); err != nil {
+			return errors.New(fmt.Sprintf("chubaofs: failed to get md5 sum of owner err(%v)", err))
+		}
+		url = fmt.Sprintf("http://%s/vol/delete?name=%s&authKey=%v", leader, name, hex.EncodeToString(key.Sum(nil)))
+	default:
+		return errors.New("chubaofs: request type not recognized! %v")
+	}
+
+	log.Infof("chubaofs: %v url(%v)", req, url)
+
+	httpResp, err := http.Get(url)
+	if err != nil {
+		errmsg := fmt.Sprintf("chubaofs: %v failed, url(%v) err(%v)", req, url, err)
+		return errors.New(errmsg)
+	}
+	defer httpResp.Body.Close()
+
+	body, err := ioutil.ReadAll(httpResp.Body)
+	if err != nil {
+		errmsg := fmt.Sprintf("chubaofs: %v failed to read http response body, bodyLen(%d) err(%v)", req, len(body), err)
+		return errors.New(errmsg)
+	}
+
+	resp := &generalVolumeResponse{}
+	if err := json.Unmarshal(body, resp); err != nil {
+		errmsg := fmt.Sprintf("chubaofs: %v failed to unmarshal, url(%v) msg(%v)", req, url, resp.Msg)
+		return errors.New(errmsg)
+	}
+
+	if resp.Code != 0 {
+		errmsg := fmt.Sprintf("chubaofs: %v failed, url(%v) code(%v) msg(%v)", req, url, resp.Code, resp.Msg)
+		return errors.New(errmsg)
+	}
+
+	log.Infof("chubaofs: %v url(%v) successful!", req, url)
+	return nil
+}
+
+func doMount(cmdName string, confFile []string) error {
+	env := []string{
+		fmt.Sprintf("PATH=%s", os.Getenv("PATH")),
+	}
+
+	for _, conf := range confFile {
+		cmd := exec.Command(cmdName, "-c", conf)
+		cmd.Env = append(cmd.Env, env...)
+		if msg, err := cmd.CombinedOutput(); err != nil {
+			return errors.New(fmt.Sprintf("chubaofs: failed to start client daemon, msg: %v , err: %v", string(msg), err))
+		}
+	}
+	return nil
+}
+
+func doUmount(mntPoints []string) error {
+	env := []string{
+		fmt.Sprintf("PATH=%s", os.Getenv("PATH")),
+	}
+
+	for _, mnt := range mntPoints {
+		cmd := exec.Command("umount", mnt)
+		cmd.Env = append(cmd.Env, env...)
+		msg, err := cmd.CombinedOutput()
+		if err != nil {
+			return errors.New(fmt.Sprintf("chubaofs: failed to umount, msg: %v , err: %v", msg, err))
+		}
+	}
+	return nil
+}
+
+/*
+ * This function creates client config files according to export locations.
+ */
+func prepareConfigFiles(d *Driver, opt *pb.CreateFileShareOpts) (configFiles, fsMntPoints []string, owner string, err error) {
+	volName := opt.GetId()
+	configFiles = make([]string, 0)
+	fsMntPoints = make([]string, 0)
+
+	/*
+	 * Check client runtime path.
+	 */
+	fi, err := os.Stat(d.conf.ClientPath)
+	if err != nil || !fi.Mode().IsDir() {
+		err = errors.New(fmt.Sprintf("chubaofs: invalid client runtime path, path: %v, err: %v", d.conf.ClientPath, err))
+		return
+	}
+
+	clientConf := path.Join(d.conf.ClientPath, volName, "conf")
+	clientLog := path.Join(d.conf.ClientPath, volName, "log")
+	clientWarnLog := path.Join(d.conf.ClientPath, volName, "warnlog")
+
+	if err = os.MkdirAll(clientConf, os.ModeDir); err != nil {
+		err = errors.New(fmt.Sprintf("chubaofs: failed to create client config dir, path: %v , err: %v", clientConf, err))
+		return
+	}
+	defer func() {
+		if err != nil {
+			log.Warningf("chubaofs: cleaning config dir, %v", clientConf)
+			os.RemoveAll(clientConf)
+		}
+	}()
+
+	if err = os.MkdirAll(clientLog, os.ModeDir); err != nil {
+		err = errors.New(fmt.Sprintf("chubaofs: failed to create client log dir, path: %v", clientLog))
+		return
+	}
+	defer func() {
+		if err != nil {
+			log.Warningf("chubaofs: cleaning log dir, %v", clientLog)
+			os.RemoveAll(clientLog)
+		}
+	}()
+
+	if err = os.MkdirAll(clientWarnLog, os.ModeDir); err != nil {
+		err = errors.New(fmt.Sprintf("chubaofs: failed to create client warn log dir, path: %v , err: %v", clientWarnLog, err))
+		return
+	}
+	defer func() {
+		if err != nil {
+			log.Warningf("chubaofs: cleaning warn log dir, %v", clientWarnLog)
+			os.RemoveAll(clientWarnLog)
+		}
+	}()
+
+	/*
+	 * Check and create mount point directory.
+	 * Mount point dir has to be newly created.
+	 */
+	locations := make([]string, 0)
+	if len(opt.ExportLocations) == 0 {
+		locations = append(locations, path.Join(d.conf.MntPoint, volName))
+	} else {
+		locations = append(locations, opt.ExportLocations...)
+	}
+
+	/*
+	 * Mount point has to be absolute path to avoid umounting the current
+	 * working directory.
+	 */
+	fsMntPoints, err = createAbsMntPoints(locations)
+	if err != nil {
+		return
+	}
+
+	defer func() {
+		if err != nil {
+			for _, mnt := range fsMntPoints {
+				os.RemoveAll(mnt)
+			}
+		}
+	}()
+
+	/*
+	 * Generate client mount config file.
+	 */
+	mntConfig := make(map[string]interface{})
+	mntConfig[KVolumeName] = volName
+	mntConfig[KMasterAddr] = strings.Join(d.conf.MasterAddr, ",")
+	mntConfig[KLogDir] = clientLog
+	mntConfig[KWarnLogDir] = clientWarnLog
+	if d.conf.LogLevel != "" {
+		mntConfig[KLogLevel] = d.conf.LogLevel
+	} else {
+		mntConfig[KLogLevel] = defaultLogLevel
+	}
+	if d.conf.Owner != "" {
+		mntConfig[KOwner] = d.conf.Owner
+	} else {
+		mntConfig[KOwner] = defaultOwner
+	}
+	if d.conf.ProfPort != "" {
+		mntConfig[KProfPort] = d.conf.ProfPort
+	} else {
+		mntConfig[KProfPort] = defaultProfPort
+	}
+
+	owner = mntConfig[KOwner].(string)
+
+	for i, mnt := range fsMntPoints {
+		mntConfig[KMountPoint] = mnt
+		data, e := json.MarshalIndent(mntConfig, "", "    ")
+		if e != nil {
+			err = errors.New(fmt.Sprintf("chubaofs: failed to generate client config file, err(%v)", e))
+			return
+		}
+		filePath := path.Join(clientConf, strconv.Itoa(i), clientConfigFileName)
+		_, e = generateFile(filePath, data)
+		if e != nil {
+			err = errors.New(fmt.Sprintf("chubaofs: failed to generate client config file, err(%v)", e))
+			return
+		}
+		configFiles = append(configFiles, filePath)
+	}
+
+	return
+}
+
+/*
+ * This function creates mount points according to the specified paths,
+ * and returns the absolute paths.
+ */
+func createAbsMntPoints(locations []string) (mntPoints []string, err error) {
+	mntPoints = make([]string, 0)
+	for _, loc := range locations {
+		mnt, e := filepath.Abs(loc)
+		if e != nil {
+			err = errors.New(fmt.Sprintf("chubaofs: failed to get absolute path of export locations, loc: %v , err: %v", loc, e))
+			return
+		}
+		if e = os.MkdirAll(mnt, os.ModeDir); e != nil {
+			err = errors.New(fmt.Sprintf("chubaofs: failed to create mount point dir, mnt: %v , err: %v", mnt, e))
+			return
+		}
+		mntPoints = append(mntPoints, mnt)
+	}
+	return
+}
+
+/*
+ * This function generates the target file with specified path, and writes data.
+ */
+func generateFile(filePath string, data []byte) (int, error) {
+	os.MkdirAll(path.Dir(filePath), os.ModePerm)
+	fw, err := os.Create(filePath)
+	if err != nil {
+		return 0, err
+	}
+	defer fw.Close()
+	return fw.Write(data)
+}

--- a/contrib/drivers/filesharedrivers/drivers.go
+++ b/contrib/drivers/filesharedrivers/drivers.go
@@ -21,6 +21,7 @@ plugin, just modify Init() and Clean() method.
 package filesharedrivers
 
 import (
+	"github.com/opensds/opensds/contrib/drivers/filesharedrivers/chubaofs"
 	"github.com/opensds/opensds/contrib/drivers/filesharedrivers/manila"
 	nfs "github.com/opensds/opensds/contrib/drivers/filesharedrivers/nfs"
 	"github.com/opensds/opensds/contrib/drivers/filesharedrivers/oceanstor"
@@ -64,6 +65,9 @@ func Init(resourceType string) FileShareDriver {
 	case config.ManilaDriverType:
 		f = &manila.Driver{}
 		break
+	case config.ChubaofsDriverType:
+		f = &chubaofs.Driver{}
+		break
 	default:
 		f = &sample.Driver{}
 		break
@@ -77,6 +81,8 @@ func Clean(f FileShareDriver) FileShareDriver {
 	// Execute different clean operations according to the FileShareDriver type.
 	switch f.(type) {
 	case *nfs.Driver:
+		break
+	case *chubaofs.Driver:
 		break
 	case *sample.Driver:
 		break

--- a/contrib/drivers/utils/config/constants.go
+++ b/contrib/drivers/utils/config/constants.go
@@ -33,6 +33,7 @@ const (
 	ScutechCMSDriverType           = "scutech_cms"
 	ManilaDriverType               = "manila"
 	FujitsuEternusDriverType       = "fujitsu_eternus"
+	ChubaofsDriverType             = "chubaofs"
 )
 
 const (

--- a/examples/driver/chubaofs.yaml
+++ b/examples/driver/chubaofs.yaml
@@ -1,0 +1,27 @@
+clusterInfo:
+  name: chubaofs-test
+  masterAddr:
+    - 192.168.0.100:80
+    - 192.168.0.101:80
+    - 192.168.0.102:80
+  volumeCapLimit: 100000
+
+runtimeEnv:
+  mntPoint: /mnt/chubaofs
+  clientPath: /var/chubaofs
+
+pool:
+  opensds-files-chubaofs:
+    diskType: NL-SAS
+    availabilityZone: default
+    multiAttach: true
+    storageType: file
+    extras:
+      dataStorage:
+        storageAccessCapability:
+          - Read
+          - Write
+          - Execute
+      ioConnectivity:
+        accessProtocol: NFS
+

--- a/pkg/dock/discovery/discovery.go
+++ b/pkg/dock/discovery/discovery.go
@@ -129,7 +129,7 @@ func (pdd *provisionDockDiscoverer) Init() error {
 	return nil
 }
 
-var filesharedrivers = []string{config.NFSDriverType, config.HuaweiOceanFileDriverType, config.ManilaDriverType}
+var filesharedrivers = []string{config.NFSDriverType, config.HuaweiOceanFileDriverType, config.ManilaDriverType, config.ChubaofsDriverType}
 
 func (pdd *provisionDockDiscoverer) Discover() error {
 	// Clear existing pool info

--- a/pkg/utils/config/config_define.go
+++ b/pkg/utils/config/config_define.go
@@ -97,6 +97,7 @@ type Backends struct {
 	NFS                  BackendProperties `conf:"nfs"`
 	Manila               BackendProperties `conf:"manila"`
 	FujitsuEternus       BackendProperties `conf:"fujitsu_eternus"`
+	Chubaofs             BackendProperties `conf:"chubaofs"`
 }
 
 type KeystoneAuthToken struct {


### PR DESCRIPTION
**What this PR does / why we need it**:

This commit introduces the chubaofs FileShareDriver.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

N/A

**Special notes for your reviewer**:

The driver has following functions implemented:

CreateFileShare/DeleteFileShare/ListPools

Note that ListPools is just a stub function since chubaofs does not have such concept as "pool". ChubaoFS is already over-provisioned.

**Release note**:

```release-note

ChubaoFS fileshare driver.

The following functions are implemented for now:
- CreateFileShare/DeleteFileShare
- ListPools

Note that ListPools is just a stub function since chubaofs does not have such concept as "pool". ChubaoFS is already over-provisioned.

The following functions are not implemented yet:
- CreateFileShareAcl/DeleteFileShareAcl
- CreateFileShareSnapshot/DeleteFileShareSnapshot

Note that the access control relies on the default UNIX file permissions, i.e. uid, gid and rwx permissions.

```
