### PR TITLE
Do not allow two profiles have same name

### DIFF
--- a/install/devsds/lib/opensds.sh
+++ b/install/devsds/lib/opensds.sh
@@ -83,8 +83,8 @@ osds::opensds::install(){
 
     export OPENSDS_AUTH_STRATEGY=$OPENSDS_AUTH_STRATEGY
     export OPENSDS_ENDPOINT=http://localhost:50040
-    build/out/bin/osdsctl profile create '{"name": "default", "description": "default policy", "storageType": "block"}'
-    build/out/bin/osdsctl profile create '{"name": "default", "description": "default policy", "storageType": "file", "provisioningProperties":{"ioConnectivity": {"accessProtocol": "NFS"},"DataStorage":{"StorageAccessCapability":["Read","Write","Execute"]}}}'
+    build/out/bin/osdsctl profile create '{"name": "default_block", "description": "default policy", "storageType": "block"}'
+    build/out/bin/osdsctl profile create '{"name": "default_file", "description": "default policy", "storageType": "file", "provisioningProperties":{"ioConnectivity": {"accessProtocol": "NFS"},"DataStorage":{"StorageAccessCapability":["Read","Write","Execute"]}}}'
 
     if [ $? == 0 ]; then
         osds::echo_summary devsds installed successfully !!

--- a/pkg/db/drivers/etcd/etcd.go
+++ b/pkg/db/drivers/etcd/etcd.go
@@ -40,10 +40,14 @@ import (
 )
 
 const (
-	defaultLimit   = 50
-	defaultOffset  = 0
-	defaultSortDir = "desc"
-	defaultSortKey = "ID"
+	defaultLimit            = 50
+	defaultOffset           = 0
+	defaultSortDir          = "desc"
+	defaultSortKey          = "ID"
+	defaultBlockProfileName = "default_block"
+	defaultFileProfileName  = "default_file"
+	typeBlock               = "block"
+	typeFile                = "file"
 )
 
 var validKey = []string{"limit", "offset", "sortDir", "sortKey"}
@@ -1510,12 +1514,12 @@ func (c *Client) getProfileByNameAndType(ctx *c.Context, name, storageType strin
 
 // GetDefaultProfile
 func (c *Client) GetDefaultProfile(ctx *c.Context) (*model.ProfileSpec, error) {
-	return c.getProfileByNameAndType(ctx, "default", "block")
+	return c.getProfileByNameAndType(ctx, defaultBlockProfileName, typeBlock)
 }
 
 // GetDefaultProfileFileShare
 func (c *Client) GetDefaultProfileFileShare(ctx *c.Context) (*model.ProfileSpec, error) {
-	return c.getProfileByNameAndType(ctx, "default", "file")
+	return c.getProfileByNameAndType(ctx, defaultFileProfileName, typeFile)
 }
 
 // ListProfiles


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Profile's name should be unique, so check that whether the profile name is unique before creating a new profile.

**Which issue this PR fixes** :
 fixes #987

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
