### PR TITLE
Fix for issue #950

### DIFF
--- a/pkg/db/drivers/etcd/etcd.go
+++ b/pkg/db/drivers/etcd/etcd.go
@@ -289,6 +289,19 @@ func (c *Client) FindFileShareValue(k string, p *model.FileShareSpec) string {
 }
 
 func (c *Client) CreateFileShareAcl(ctx *c.Context, fshare *model.FileShareAclSpec) (*model.FileShareAclSpec, error) {
+	acls, err := c.ListFileSharesAcl(ctx)
+	if err != nil {
+		log.Error("failed to list acls")
+		return nil, err
+	}
+
+	for _, acl := range acls {
+		if acl.AccessTo == fshare.AccessTo {
+			errstr :=  "acl already exists for this ip: "+acl.AccessTo+". If you want to set new acl, first delete the existing one"
+			log.Error(errstr)
+			return nil, fmt.Errorf(errstr)
+		}
+	}
 
 	fshare.TenantId = ctx.TenantId
 	fshareBody, err := json.Marshal(fshare)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fix for issue #950 
It doesn't allow duplication of IP while creating acl rule
 
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Test results are here
```
root@shruthi-VirtualBox:~/go/src/github.com/opensds/opensds# curl --header "Content-Type: application/json" --data '{"fileshareId":"0635351a-b254-4365-92b5-a75d20afc13f", "accessTo":"10.2.3.4", "accessCapability":["read", "write"], "type":"ip"}' http://127.0.0.1:50040/v1beta/e93b4c0934da416eb9c8d120c5d04d96/file/acls 
{"id":"43941892-269b-436a-b6f2-f831aa33ae33","createdAt":"2019-10-03T13:04:19","updatedAt":"2019-10-03T13:04:19","tenantId":"e93b4c0934da416eb9c8d120c5d04d96","fileshareId":"0635351a-b254-4365-92b5-a75d20afc13f","type":"ip","accessCapability":["read","write"],"accessTo":"10.2.3.4","profileId":"635b98f9-e178-4041-a46e-aab3fcbef0c2"}root@shruthi-VirtualBox:~/go/src/github.com/opensds/opensds# 
root@shruthi-VirtualBox:~/go/src/github.com/opensds/opensds# 
```
```
root@shruthi-VirtualBox:~/go/src/github.com/opensds/opensds# exportfs -v
/var/sdf1     	10.2.3.4(rw,wdelay,root_squash,no_subtree_check,sec=sys,rw,root_squash,no_all_squash)
root@shruthi-VirtualBox:~/go/src/github.com/opensds/opensds# 
root@shruthi-VirtualBox:~/go/src/github.com/opensds/opensds# curl --header "Content-Type: application/json" --data '{"fileshareId":"0635351a-b254-4365-92b5-a75d20afc13f", "accessTo":"10.2.3.4", "accessCapability":["read", "write"], "type":"ip"}' http://127.0.0.1:50040/v1beta/e93b4c0934da416eb9c8d120c5d04d96/file/acls 
{"code":400,"message":"createFileshareAcldbentry failed: ip already exists: 10.2.3.4"}root@shruthi-VirtualBox:~/go/src/github.com/opensds/opensds# 
root@shruthi-VirtualBox:~/go/src/github.com/opensds/opensds#
```
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
