### PR TITLE
Support pool status

### DIFF
--- a/install/CI/test
+++ b/install/CI/test
@@ -28,7 +28,7 @@ split_line(){
 
 # Start the openapi-spec validation.
 split_line "Start openapi-spec validation"
-wget https://github.com/go-swagger/go-swagger/releases/download/v0.19.0/swagger_linux_amd64
+wget https://github.com/go-swagger/go-swagger/releases/download/v0.19.0/swagger_linux_amd64 -O swagger_linux_amd64
 chmod +x ./swagger_linux_amd64 && ./swagger_linux_amd64 validate --stop-on-error openapi-spec/swagger.yaml
 rm ./swagger_linux_amd64
 

--- a/pkg/dock/discovery/discovery.go
+++ b/pkg/dock/discovery/discovery.go
@@ -186,7 +186,7 @@ func (pdd *provisionDockDiscoverer) Discover() error {
 	ctx := c.NewAdminContext()
 	polsInDb, err = pdd.c.ListPools(ctx)
 	if err != nil {
-		return fmt.Errorf("Can not read pools in db")
+		return fmt.Errorf("can not read pools in db")
 	}
 	dbPolsMap := make(map[string]*model.StoragePoolSpec)
 	for _, polInDb := range polsInDb {
@@ -200,7 +200,7 @@ func (pdd *provisionDockDiscoverer) Discover() error {
 		pdd.pols = append(pdd.pols, unavailablePol)
 	}
 	if len(pdd.pols) == 0 {
-		return fmt.Errorf("There is no pool can be found.")
+		return fmt.Errorf("there is no pool can be found")
 	}
 
 	return nil

--- a/pkg/dock/discovery/discovery.go
+++ b/pkg/dock/discovery/discovery.go
@@ -39,6 +39,11 @@ import (
 	uuid "github.com/satori/go.uuid"
 )
 
+const (
+	availableStatus = "available"
+	unavailableStatus = "unavailable"
+)
+
 type Context struct {
 	StopChan chan bool
 	ErrChan  chan error
@@ -135,6 +140,7 @@ func (pdd *provisionDockDiscoverer) Discover() error {
 	// Clear existing pool info
 	pdd.pols = pdd.pols[:0]
 	var pols []*model.StoragePoolSpec
+	var polsInDb []*model.StoragePoolSpec
 	var err error
 	for _, dck := range pdd.dcks {
 		// Call function of StorageDrivers configured by storage drivers.
@@ -145,6 +151,7 @@ func (pdd *provisionDockDiscoverer) Discover() error {
 			for _, pol := range pols {
 				log.Infof("Backend %s discovered pool %s", dck.DriverName, pol.Name)
 				pol.DockId = dck.Id
+				pol.Status = availableStatus
 			}
 		} else {
 			d := drivers.Init(dck.DriverName)
@@ -162,6 +169,7 @@ func (pdd *provisionDockDiscoverer) Discover() error {
 				pol.DockId = dck.Id
 				pol.ReplicationType = replicationType
 				pol.ReplicationDriverName = replicationDriverName
+				pol.Status = availableStatus
 			}
 		}
 		if err != nil {
@@ -174,6 +182,22 @@ func (pdd *provisionDockDiscoverer) Discover() error {
 		}
 
 		pdd.pols = append(pdd.pols, pols...)
+	}
+	ctx := c.NewAdminContext()
+	polsInDb, err = pdd.c.ListPools(ctx)
+	if err != nil {
+		return fmt.Errorf("Can not read pools in db")
+	}
+	dbPolsMap := make(map[string]*model.StoragePoolSpec)
+	for _, polInDb := range polsInDb {
+		dbPolsMap[polInDb.Id] = polInDb
+	}
+	for _, pol := range pdd.pols {
+		delete(dbPolsMap, pol.Id)
+	}
+	for _, unavailablePol := range dbPolsMap {
+		unavailablePol.Status = unavailableStatus
+		pdd.pols = append(pdd.pols, unavailablePol)
 	}
 	if len(pdd.pols) == 0 {
 		return fmt.Errorf("There is no pool can be found.")

--- a/pkg/dock/discovery/discovery_test.go
+++ b/pkg/dock/discovery/discovery_test.go
@@ -80,8 +80,17 @@ func TestDiscover(t *testing.T) {
 		fdd.dcks = append(fdd.dcks, &SampleDocks[i])
 	}
 	for i := range SamplePools {
+		fdd.pols = append(fdd.pols, &SamplePools[i])
 		expected = append(expected, &SamplePools[i])
 	}
+	mockClient := new(dbtest.Client)
+	mockClient.On("CreateDock", c.NewAdminContext(), fdd.dcks[0]).Return(nil, nil)
+	mockClient.On("CreatePool", c.NewAdminContext(), fdd.pols[0]).Return(nil, nil)
+	mockClient.On("CreatePool", c.NewAdminContext(), fdd.pols[1]).Return(nil, nil)
+	mockClient.On("CreatePool", c.NewAdminContext(), fdd.pols[2]).Return(nil, nil)
+	mockClient.On("ListPools", c.NewAdminContext()).Return(fdd.pols, nil)
+	fdd.c = mockClient
+
 	if err := fdd.Discover(); err != nil {
 		t.Errorf("Failed to discoverer pools: %v\n", err)
 	}

--- a/pkg/dock/discovery/discovery_test.go
+++ b/pkg/dock/discovery/discovery_test.go
@@ -84,10 +84,6 @@ func TestDiscover(t *testing.T) {
 		expected = append(expected, &SamplePools[i])
 	}
 	mockClient := new(dbtest.Client)
-	mockClient.On("CreateDock", c.NewAdminContext(), fdd.dcks[0]).Return(nil, nil)
-	mockClient.On("CreatePool", c.NewAdminContext(), fdd.pols[0]).Return(nil, nil)
-	mockClient.On("CreatePool", c.NewAdminContext(), fdd.pols[1]).Return(nil, nil)
-	mockClient.On("CreatePool", c.NewAdminContext(), fdd.pols[2]).Return(nil, nil)
 	mockClient.On("ListPools", c.NewAdminContext()).Return(fdd.pols, nil)
 	fdd.c = mockClient
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
When we query pool list, we can see a item "Status" which is always empty.
This PR add the status to each pool and it would be displayed in the pool list.
When the pool was deleted in backend, the status would be "unavailable", otherwise it would be "available".

**Which issue this PR fixes** : fixes #1015

**Special notes for your reviewer**: None

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
root@ubuntu:~/gopath/src/github.com/opensds/opensds (master) #  ./build/out/bin/osdsctl pool list
WARNING: OPENSDS_ENDPOINT is not specified, use default(http://localhost:50040)
WARNING: Not found Env OPENSDS_AUTH_STRATEGY, use default(noauth)
+--------------------------------------+-------------------------+-------------+-----------+---------------+--------------+
| Id                                   | Name                    | Description | Status    | TotalCapacity | FreeCapacity |
+--------------------------------------+-------------------------+-------------+-----------+---------------+--------------+
| 18272d49-3c58-59f2-82a5-0a5134786ba2 | opensds-volumes-default |             | available | 20            | 20           |
| 16e17837-0319-5381-bd67-0cbfe73d3ff7 | opensds-files-default   |             | available | 20            | 20           |
+--------------------------------------+-------------------------+-------------+-----------+---------------+--------------+
root@ubuntu:~/gopath/src/github.com/opensds/opensds (master) # vgremove opensds-volumes-default
  Volume group "opensds-volumes-default" successfully removed
root@ubuntu:~/gopath/src/github.com/opensds/opensds (master) # ./build/out/bin/osdsctl pool list
WARNING: OPENSDS_ENDPOINT is not specified, use default(http://localhost:50040)
WARNING: Not found Env OPENSDS_AUTH_STRATEGY, use default(noauth)
+--------------------------------------+-------------------------+-------------+-------------+---------------+--------------+
| Id                                   | Name                    | Description | Status      | TotalCapacity | FreeCapacity |
+--------------------------------------+-------------------------+-------------+-------------+---------------+--------------+
| 18272d49-3c58-59f2-82a5-0a5134786ba2 | opensds-volumes-default |             | unavailable | 20            | 20           |
| 16e17837-0319-5381-bd67-0cbfe73d3ff7 | opensds-files-default   |             | available   | 20            | 20           |
+--------------------------------------+-------------------------+-------------+-------------+---------------+--------------+
root@ubuntu:~/gopath/src/github.com/opensds/opensds (master) #
```
