### PR TITLE
Support dock import by command 'osdsctl dock import'

### DIFF
--- a/install/CI/test
+++ b/install/CI/test
@@ -28,7 +28,7 @@ split_line(){
 
 # Start the openapi-spec validation.
 split_line "Start openapi-spec validation"
-wget https://github.com/go-swagger/go-swagger/releases/download/v0.19.0/swagger_linux_amd64
+wget https://github.com/go-swagger/go-swagger/releases/download/v0.19.0/swagger_linux_amd64 -O swagger_linux_amd64
 chmod +x ./swagger_linux_amd64 && ./swagger_linux_amd64 validate --stop-on-error openapi-spec/swagger.yaml
 rm ./swagger_linux_amd64
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support the command "osdsctl dock import" to add backend.

**Which issue this PR fixes** : fixes #1004

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
root@node01:~/gopath/src/github.com/opensds/opensds (SupportDockImport) # ./build/out/bin/osdsctl pool list
WARNING: OPENSDS_ENDPOINT is not specified, use default(http://localhost:50040)
WARNING: Not found Env OPENSDS_AUTH_STRATEGY, use default(noauth)
+----+------+-------------+--------+---------------+--------------+
| Id | Name | Description | Status | TotalCapacity | FreeCapacity |
+----+------+-------------+--------+---------------+--------------+
+----+------+-------------+--------+---------------+--------------+
root@node01:~/gopath/src/github.com/opensds/opensds (SupportDockImport) # ./build/out/bin/osdsctl dock list
WARNING: OPENSDS_ENDPOINT is not specified, use default(http://localhost:50040)
WARNING: Not found Env OPENSDS_AUTH_STRATEGY, use default(noauth)
+----+------+-------------+----------+------------+
| Id | Name | Description | Endpoint | DriverName |
+----+------+-------------+----------+------------+
+----+------+-------------+----------+------------+
root@node01:~/gopath/src/github.com/opensds/opensds (SupportDockImport) # cat dock.yaml
[lvm]
name = lvm
description = LVM Test
driver_name = lvm
config_path = /etc/opensds/driver/lvm.yaml
root@node01:~/gopath/src/github.com/opensds/opensds (SupportDockImport) # cat pool.yaml
tgtBindIp: 10.10.3.111
tgtConfDir: /etc/tgt/conf.d
pool:
  ubuntu-vg:
    diskType: NL-SAS
    availabilityZone: default
    multiAttach: true
    storageType: block
    extras:
      dataStorage:
        provisioningPolicy: Thin
        isSpaceEfficient: false
      ioConnectivity:
        accessProtocol: iscsi
        maxIOPS: 7000000
        maxBWS: 600
      advanced:
        diskType: SSD
        latency: 5ms

root@node01:~/gopath/src/github.com/opensds/opensds (SupportDockImport) # ./build/out/bin/osdsctl dock import lvm dock.yaml -p pool.yaml
WARNING: OPENSDS_ENDPOINT is not specified, use default(http://localhost:50040)
WARNING: Not found Env OPENSDS_AUTH_STRATEGY, use default(noauth)
root@node01:~/gopath/src/github.com/opensds/opensds (SupportDockImport) # killall osdsdock osdslet osdsapiserver
root@node01:~/gopath/src/github.com/opensds/opensds (SupportDockImport) # ./build/out/bin/osdsdock -daemon
2019/11/05 10:14:05 Command: modprobe nvme-rdma:
./build/out/bin/osdsdock [PID] 23583 running...
root@node01:~/gopath/src/github.com/opensds/opensds (SupportDockImport) # ./build/out/bin/osdslet -daemon
./build/out/bin/osdslet [PID] 23605 running...
root@node01:~/gopath/src/github.com/opensds/opensds (SupportDockImport) # ./build/out/bin/osdsapiserver -daemon
./build/out/bin/osdsapiserver [PID] 23627 running...
root@node01:~/gopath/src/github.com/opensds/opensds (SupportDockImport) # ./build/out/bin/osdsctl dock list
WARNING: OPENSDS_ENDPOINT is not specified, use default(http://localhost:50040)
WARNING: Not found Env OPENSDS_AUTH_STRATEGY, use default(noauth)
+--------------------------------------+------+-------------+-------------------+------------+
| Id                                   | Name | Description | Endpoint          | DriverName |
+--------------------------------------+------+-------------+-------------------+------------+
| 7c0511a5-fc99-559e-b72c-2b0fefc2105c | lvm  | LVM Test    | 10.10.3.111:50050 | lvm        |
+--------------------------------------+------+-------------+-------------------+------------+
root@node01:~/gopath/src/github.com/opensds/opensds (SupportDockImport) # ./build/out/bin/osdsctl pool list
WARNING: OPENSDS_ENDPOINT is not specified, use default(http://localhost:50040)
WARNING: Not found Env OPENSDS_AUTH_STRATEGY, use default(noauth)
+--------------------------------------+-----------+-------------+--------+---------------+--------------+
| Id                                   | Name      | Description | Status | TotalCapacity | FreeCapacity |
+--------------------------------------+-----------+-------------+--------+---------------+--------------+
| 0ccb1fb8-f230-5e20-b48f-e43cb80ca73f | ubuntu-vg |             |        | 110           | 0            |
+--------------------------------------+-----------+-------------+--------+---------------+--------------+
root@node01:~/gopath/src/github.com/opensds/opensds (SupportDockImport) #
```
