### PR TITLE
Fileshare name supports upto 255 characters name length

### DIFF
--- a/pkg/api/util/db.go
+++ b/pkg/api/util/db.go
@@ -176,8 +176,8 @@ func CreateFileShareDBEntry(ctx *c.Context, in *model.FileShareSpec) (*model.Fil
 		log.Error(errMsg)
 		return nil, errors.New(errMsg)
 	}
-	if len(in.Name) > 128 {
-		errMsg := fmt.Sprintf("fileshare name length should not more than 128 characters. current length is : %d", len(in.Name))
+	if len(in.Name) > 255 {
+		errMsg := fmt.Sprintf("fileshare name length should not be more than 255 characters. input name length is : %d", len(in.Name))
 		log.Error(errMsg)
 		return nil, errors.New(errMsg)
 	}

--- a/pkg/api/util/db_test.go
+++ b/pkg/api/util/db_test.go
@@ -16,6 +16,7 @@ package util
 
 import (
 	"fmt"
+	"github.com/opensds/opensds/pkg/utils"
 	"reflect"
 	"strconv"
 	"testing"
@@ -431,14 +432,99 @@ func TestCreateFileShareDBEntry(t *testing.T) {
 		assertTestResult(t, err.Error(), expectedError)
 	})
 
-	t.Run("File share name length more than 128 characters are not allowed", func(t *testing.T) {
-		in.Size, in.Name, in.ProfileId = int64(1), "kjxdpvfuenecpyhbxdumwibipjkigcjykabuhghjghjgjgjgjgjghhkkkkkkkkkkkkkkklsccdesnkgxnjnhfjusigceorogdgjlyciemscgvncerucokfekdiviuyplbly", "b3585ebe-c42c-120g-b28e-f373746a71ca"
+	t.Run("File share name length equal to 0 character are not allowed", func(t *testing.T) {
+		in.Name = utils.RandomString(0)
+		in.Size, in.ProfileId = int64(1), "b3585ebe-c42c-120g-b28e-f373746a71ca"
 		mockClient := new(dbtest.Client)
 		mockClient.On("CreateFileShare", context.NewAdminContext(), in).Return(&SampleFileShares[0], nil)
 		db.C = mockClient
 
 		_, err := CreateFileShareDBEntry(context.NewAdminContext(), in)
-		expectedError := "fileshare name length should not more than 128 characters. current length is : " + strconv.Itoa(len(in.Name))
+		expectedError := "empty fileshare name is not allowed. Please give valid name."
+		assertTestResult(t, err.Error(), expectedError)
+	})
+
+	t.Run("File share name length equal to 1 character are allowed", func(t *testing.T) {
+		in.Name = utils.RandomString(1)
+		in.Size, in.ProfileId = int64(1), "b3585ebe-c42c-120g-b28e-f373746a71ca"
+		mockClient := new(dbtest.Client)
+		mockClient.On("CreateFileShare", context.NewAdminContext(), in).Return(&SampleFileShares[0], nil)
+		db.C = mockClient
+
+		var expected = &SampleFileShares[0]
+		result, err := CreateFileShareDBEntry(context.NewAdminContext(), in)
+		if err != nil {
+			t.Errorf("failed to create fileshare err is %v\n", err)
+		}
+		assertTestResult(t, result, expected)
+	})
+
+	t.Run("File share name length equal to 10 characters are allowed", func(t *testing.T) {
+		in.Name = utils.RandomString(10)
+		in.Size, in.ProfileId = int64(1), "b3585ebe-c42c-120g-b28e-f373746a71ca"
+		mockClient := new(dbtest.Client)
+		mockClient.On("CreateFileShare", context.NewAdminContext(), in).Return(&SampleFileShares[0], nil)
+		db.C = mockClient
+
+		var expected = &SampleFileShares[0]
+		result, err := CreateFileShareDBEntry(context.NewAdminContext(), in)
+		if err != nil {
+			t.Errorf("failed to create fileshare err is %v\n", err)
+		}
+		assertTestResult(t, result, expected)
+	})
+
+	t.Run("File share name length equal to 254 characters are allowed", func(t *testing.T) {
+		in.Name = utils.RandomString(254)
+		in.Size, in.ProfileId = int64(1), "b3585ebe-c42c-120g-b28e-f373746a71ca"
+		mockClient := new(dbtest.Client)
+		mockClient.On("CreateFileShare", context.NewAdminContext(), in).Return(&SampleFileShares[0], nil)
+		db.C = mockClient
+
+		var expected = &SampleFileShares[0]
+		result, err := CreateFileShareDBEntry(context.NewAdminContext(), in)
+		if err != nil {
+			t.Errorf("failed to create fileshare err is %v\n", err)
+		}
+		assertTestResult(t, result, expected)
+	})
+
+	t.Run("File share name length equal to 255 characters are allowed", func(t *testing.T) {
+		in.Name = utils.RandomString(255)
+		in.Size, in.ProfileId = int64(1), "b3585ebe-c42c-120g-b28e-f373746a71ca"
+		mockClient := new(dbtest.Client)
+		mockClient.On("CreateFileShare", context.NewAdminContext(), in).Return(&SampleFileShares[0], nil)
+		db.C = mockClient
+
+		var expected = &SampleFileShares[0]
+		result, err := CreateFileShareDBEntry(context.NewAdminContext(), in)
+		if err != nil {
+			t.Errorf("failed to create fileshare err is %v\n", err)
+		}
+		assertTestResult(t, result, expected)
+	})
+
+	t.Run("File share name length more than 255 characters are not allowed", func(t *testing.T) {
+		in.Name = utils.RandomString(256)
+		in.Size, in.ProfileId = int64(1), "b3585ebe-c42c-120g-b28e-f373746a71ca"
+		mockClient := new(dbtest.Client)
+		mockClient.On("CreateFileShare", context.NewAdminContext(), in).Return(&SampleFileShares[0], nil)
+		db.C = mockClient
+
+		_, err := CreateFileShareDBEntry(context.NewAdminContext(), in)
+		expectedError := "fileshare name length should not be more than 255 characters. input name length is : "+strconv.Itoa(len(in.Name))
+		assertTestResult(t, err.Error(), expectedError)
+	})
+
+	t.Run("File share name length more than 255 characters are not allowed", func(t *testing.T) {
+		in.Name = utils.RandomString(257)
+		in.Size, in.ProfileId = int64(1), "b3585ebe-c42c-120g-b28e-f373746a71ca"
+		mockClient := new(dbtest.Client)
+		mockClient.On("CreateFileShare", context.NewAdminContext(), in).Return(&SampleFileShares[0], nil)
+		db.C = mockClient
+
+		_, err := CreateFileShareDBEntry(context.NewAdminContext(), in)
+		expectedError := "fileshare name length should not be more than 255 characters. input name length is : "+strconv.Itoa(len(in.Name))
 		assertTestResult(t, err.Error(), expectedError)
 	})
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -250,3 +250,13 @@ func WaitForCondition(f func() (bool, error), interval, timeout time.Duration) e
 	}
 	return fmt.Errorf("wait for condition timeout")
 }
+
+func RandomString(n int) string {
+	var letter = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letter[rand.Intn(len(letter))]
+	}
+	return string(b)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fix for Bug #1008  Fileshare name supports upto 255 characters name length
As unix operating system supports upto 255 characters.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
