### PR TITLE
Integrate all the "select" function to a single one

### DIFF
--- a/pkg/db/drivers/etcd/etcd.go
+++ b/pkg/db/drivers/etcd/etcd.go
@@ -51,7 +51,7 @@ var validKey = []string{"limit", "offset", "sortDir", "sortKey"}
 
 const (
 	typeFileShares         string = "FileShares"
-	typeFileShareSnapshots string = "FileShareSnapshot"
+	typeFileShareSnapshots string = "FileShareSnapshots"
 	typeDocks              string = "Docks"
 	typePools              string = "Pools"
 	typeProfiles           string = "Profiles"

--- a/pkg/db/drivers/etcd/etcd.go
+++ b/pkg/db/drivers/etcd/etcd.go
@@ -330,33 +330,6 @@ func (c *Client) CreateFileShare(ctx *c.Context, fshare *model.FileShareSpec) (*
 	return fshare, nil
 }
 
-func (c *Client) SelectFileShares(m map[string][]string, fileshares []*model.FileShareSpec) []*model.FileShareSpec {
-	if !c.SelectOrNot(m) {
-		return fileshares
-	}
-
-	var fshares = []*model.FileShareSpec{}
-	var flag bool
-	for _, fshare := range fileshares {
-		flag = true
-		for key := range m {
-			if utils.Contained(key, validKey) {
-				continue
-			}
-			f := c.FindFileShareValue(key, fshare)
-			if !strings.EqualFold(m[key][0], f) {
-				flag = false
-				break
-			}
-		}
-		if flag {
-			fshares = append(fshares, fshare)
-		}
-	}
-	return fshares
-
-}
-
 func (c *Client) SortFileShares(shares []*model.FileShareSpec, p *Parameter) []*model.FileShareSpec {
 	volume_sortKey = p.sortKey
 
@@ -446,9 +419,16 @@ func (c *Client) ListFileSharesWithFilter(ctx *c.Context, m map[string][]string)
 		return nil, err
 	}
 
-	vols := c.SelectFileShares(m, fileshares)
-	p := c.ParameterFilter(m, len(vols), []string{"ID", "NAME", "STATUS", "AVAILABILITYZONE", "PROFILEID", "CRETEDAT", "UPDATEDAT", "PROTOCOLS", "EXPORTLOCATIONS", "SNAPSHOTID"})
-	return c.SortFileShares(vols, p), nil
+	datas := c.SelectDatas(m, utils.Slice(fileshares, 0, len(fileshares)).([]interface{}))
+	var fs []*model.FileShareSpec
+	for _, data := range datas {
+		p, ok := data.(*model.FileShareSpec)
+		if ok {
+			fs = append(fs, p)
+		}
+	}
+	p := c.ParameterFilter(m, len(fs), []string{"ID", "NAME", "STATUS", "AVAILABILITYZONE", "PROFILEID", "CRETEDAT", "UPDATEDAT", "PROTOCOLS", "EXPORTLOCATIONS", "SNAPSHOTID"})
+	return c.SortFileShares(fs, p), nil
 }
 
 // ListFileShares
@@ -815,33 +795,6 @@ func (c *Client) FindFileShareSnapshotsValue(k string, p *model.FileShareSnapsho
 	return ""
 }
 
-func (c *Client) SelectFileShareSnapshots(m map[string][]string, snapshots []*model.FileShareSnapshotSpec) []*model.FileShareSnapshotSpec {
-	if !c.SelectOrNot(m) {
-		return snapshots
-	}
-
-	var snps = []*model.FileShareSnapshotSpec{}
-	var flag bool
-	for _, snapshot := range snapshots {
-		flag = true
-		for key := range m {
-			if utils.Contained(key, validKey) {
-				continue
-			}
-			v := c.FindFileShareSnapshotsValue(key, snapshot)
-			if !strings.EqualFold(m[key][0], v) {
-				flag = false
-				break
-			}
-		}
-		if flag {
-			snps = append(snps, snapshot)
-		}
-	}
-	return snps
-
-}
-
 func (c *Client) SortFileShareSnapshots(snapshots []*model.FileShareSnapshotSpec, p *Parameter) []*model.FileShareSnapshotSpec {
 	fileshareSnapshotSortKey = p.sortKey
 
@@ -861,7 +814,14 @@ func (c *Client) ListFileShareSnapshotsWithFilter(ctx *c.Context, m map[string][
 		return nil, err
 	}
 
-	snps := c.SelectFileShareSnapshots(m, fileshareSnapshots)
+	datas := c.SelectDatas(m, utils.Slice(fileshareSnapshots, 0, len(fileshareSnapshots)).([]interface{}))
+	var snps []*model.FileShareSnapshotSpec
+	for _, data := range datas {
+		p, ok := data.(*model.FileShareSnapshotSpec)
+		if ok {
+			snps = append(snps, p)
+		}
+	}
 	p := c.ParameterFilter(m, len(snps), []string{"ID", "VOLUMEID", "STATUS", "USERID", "PROJECTID"})
 
 	return c.SortFileShareSnapshots(snps, p)[p.beginIdx:p.endIdx], nil
@@ -1085,32 +1045,6 @@ func (c *Client) FindDockValue(k string, d *model.DockSpec) string {
 	return ""
 }
 
-func (c *Client) SelectDocks(m map[string][]string, docks []*model.DockSpec) []*model.DockSpec {
-	if !c.SelectOrNot(m) {
-		return docks
-	}
-	var dcks = []*model.DockSpec{}
-
-	var flag bool
-	for _, dock := range docks {
-		flag = true
-		for key := range m {
-			if utils.Contained(key, validKey) {
-				continue
-			}
-			v := c.FindDockValue(key, dock)
-			if !strings.EqualFold(m[key][0], v) {
-				flag = false
-				break
-			}
-		}
-		if flag {
-			dcks = append(dcks, dock)
-		}
-	}
-	return dcks
-}
-
 func (c *Client) SortDocks(dcks []*model.DockSpec, p *Parameter) []*model.DockSpec {
 	dockSortKey = p.sortKey
 	if strings.EqualFold(p.sortDir, "asc") {
@@ -1128,7 +1062,14 @@ func (c *Client) ListDocksWithFilter(ctx *c.Context, m map[string][]string) ([]*
 		return nil, err
 	}
 
-	dcks := c.SelectDocks(m, docks)
+	datas := c.SelectDatas(m, utils.Slice(docks, 0, len(docks)).([]interface{}))
+	var dcks []*model.DockSpec
+	for _, data := range datas {
+		p, ok := data.(*model.DockSpec)
+		if ok {
+			dcks = append(dcks, p)
+		}
+	}
 
 	p := c.ParameterFilter(m, len(dcks), []string{"ID", "NAME", "ENDPOINT", "DRIVERNAME", "DESCRIPTION", "STATUS"})
 	return c.SortDocks(dcks, p)[p.beginIdx:p.endIdx], nil
@@ -1260,32 +1201,6 @@ func (c *Client) FindPoolValue(k string, p *model.StoragePoolSpec) string {
 	return ""
 }
 
-func (c *Client) SelectPools(m map[string][]string, pools []*model.StoragePoolSpec) []*model.StoragePoolSpec {
-
-	if !c.SelectOrNot(m) {
-		return pools
-	}
-	var pols = []*model.StoragePoolSpec{}
-	var flag bool
-	for _, pool := range pools {
-		flag = true
-		for key := range m {
-			if utils.Contained(key, validKey) {
-				continue
-			}
-			v := c.FindPoolValue(key, pool)
-			if !strings.EqualFold(m[key][0], v) {
-				flag = false
-				break
-			}
-		}
-		if flag {
-			pols = append(pols, pool)
-		}
-	}
-	return pols
-}
-
 func (c *Client) SortPools(pools []*model.StoragePoolSpec, p *Parameter) []*model.StoragePoolSpec {
 
 	poolSortKey = p.sortKey
@@ -1305,7 +1220,14 @@ func (c *Client) ListPoolsWithFilter(ctx *c.Context, m map[string][]string) ([]*
 		return nil, err
 	}
 
-	pols := c.SelectPools(m, pools)
+	datas := c.SelectDatas(m, utils.Slice(pools, 0, len(pools)).([]interface{}))
+	var pols []*model.StoragePoolSpec
+	for _, data := range datas {
+		p, ok := data.(*model.StoragePoolSpec)
+		if ok {
+			pols = append(pols, p)
+		}
+	}
 	p := c.ParameterFilter(m, len(pols), []string{"ID", "NAME", "STATUS", "AVAILABILITYZONE", "DOCKID", "DESCRIPTION"})
 	return c.SortPools(pols, p)[p.beginIdx:p.endIdx], nil
 }
@@ -1596,33 +1518,6 @@ func (c *Client) SortProfiles(profiles []*model.ProfileSpec, p *Parameter) []*mo
 	return profiles
 }
 
-func (c *Client) SelectProfiles(m map[string][]string, profiles []*model.ProfileSpec) []*model.ProfileSpec {
-	if !c.SelectOrNot(m) {
-		return profiles
-	}
-
-	var prfs = []*model.ProfileSpec{}
-	var flag bool
-	for _, profile := range profiles {
-		flag = true
-		for key := range m {
-			if utils.Contained(key, validKey) {
-				continue
-			}
-			v := c.FindProfileValue(key, profile)
-			if !strings.EqualFold(m[key][0], v) {
-				flag = false
-				break
-			}
-		}
-		if flag {
-			prfs = append(prfs, profile)
-		}
-	}
-	return prfs
-
-}
-
 func (c *Client) ListProfilesWithFilter(ctx *c.Context, m map[string][]string) ([]*model.ProfileSpec, error) {
 	profiles, err := c.ListProfiles(ctx)
 	if err != nil {
@@ -1630,8 +1525,14 @@ func (c *Client) ListProfilesWithFilter(ctx *c.Context, m map[string][]string) (
 		return nil, err
 	}
 
-	prfs := c.SelectProfiles(m, profiles)
-
+	datas := c.SelectDatas(m, utils.Slice(profiles, 0, len(profiles)).([]interface{}))
+	var prfs []*model.ProfileSpec
+	for _, data := range datas {
+		p, ok := data.(*model.ProfileSpec)
+		if ok {
+			prfs = append(prfs, p)
+		}
+	}
 	p := c.ParameterFilter(m, len(prfs), []string{"ID", "NAME", "DESCRIPTION"})
 
 	return c.SortProfiles(prfs, p)[p.beginIdx:p.endIdx], nil
@@ -1919,31 +1820,33 @@ func (c *Client) FindVolumeValue(k string, p *model.VolumeSpec) string {
 	return ""
 }
 
-func (c *Client) SelectVolumes(m map[string][]string, volumes []*model.VolumeSpec) []*model.VolumeSpec {
+func (c *Client) SelectDatas(m map[string][]string, datas []interface{}) []interface{} {
 	if !c.SelectOrNot(m) {
-		return volumes
+		return datas
 	}
-
-	var vols = []*model.VolumeSpec{}
-	var flag bool
-	for _, vol := range volumes {
-		flag = true
+	var ret []interface{}
+	for i := 0; i < len(datas); i++ {
+		c, err := utils.StructToMap(datas[i])
+		if err != nil {
+			log.Error("call StructToMap failed: ", err)
+			return nil
+		}
+		selected := true
 		for key := range m {
 			if utils.Contained(key, validKey) {
 				continue
 			}
-			v := c.FindVolumeValue(key, vol)
-			if !strings.EqualFold(m[key][0], v) {
-				flag = false
+
+			if c[utils.LowerCaseFirst(key)] == "" || c[utils.LowerCaseFirst(key)] != m[key][0] {
+				selected = false
 				break
 			}
 		}
-		if flag {
-			vols = append(vols, vol)
+		if selected {
+			ret = append(ret, datas[i])
 		}
 	}
-	return vols
-
+	return ret
 }
 
 func (c *Client) SortVolumes(volumes []*model.VolumeSpec, p *Parameter) []*model.VolumeSpec {
@@ -1965,8 +1868,14 @@ func (c *Client) ListVolumesWithFilter(ctx *c.Context, m map[string][]string) ([
 		return nil, err
 	}
 
-	vols := c.SelectVolumes(m, volumes)
-
+	datas := c.SelectDatas(m, utils.Slice(volumes, 0, len(volumes)).([]interface{}))
+	var vols []*model.VolumeSpec
+	for _, data := range datas {
+		p, ok := data.(*model.VolumeSpec)
+		if ok {
+			vols = append(vols, p)
+		}
+	}
 	p := c.ParameterFilter(m, len(vols), []string{"ID", "NAME", "STATUS", "AVAILABILITYZONE", "PROFILEID", "PROJECTID", "SIZE", "POOLID", "DESCRIPTION", "GROUPID"})
 
 	return c.SortVolumes(vols, p)[p.beginIdx:p.endIdx], nil
@@ -2431,33 +2340,6 @@ func (c *Client) FindSnapshotsValue(k string, p *model.VolumeSnapshotSpec) strin
 	return ""
 }
 
-func (c *Client) SelectSnapshots(m map[string][]string, snapshots []*model.VolumeSnapshotSpec) []*model.VolumeSnapshotSpec {
-	if !c.SelectOrNot(m) {
-		return snapshots
-	}
-
-	var snps = []*model.VolumeSnapshotSpec{}
-	var flag bool
-	for _, snapshot := range snapshots {
-		flag = true
-		for key := range m {
-			if utils.Contained(key, validKey) {
-				continue
-			}
-			v := c.FindSnapshotsValue(key, snapshot)
-			if !strings.EqualFold(m[key][0], v) {
-				flag = false
-				break
-			}
-		}
-		if flag {
-			snps = append(snps, snapshot)
-		}
-	}
-	return snps
-
-}
-
 func (c *Client) SortSnapshots(snapshots []*model.VolumeSnapshotSpec, p *Parameter) []*model.VolumeSnapshotSpec {
 	volumeSnapshotSortKey = p.sortKey
 
@@ -2477,7 +2359,14 @@ func (c *Client) ListVolumeSnapshotsWithFilter(ctx *c.Context, m map[string][]st
 		return nil, err
 	}
 
-	snps := c.SelectSnapshots(m, volumeSnapshots)
+	datas := c.SelectDatas(m, utils.Slice(volumeSnapshots, 0, len(volumeSnapshots)).([]interface{}))
+	var snps []*model.VolumeSnapshotSpec
+	for _, data := range datas {
+		p, ok := data.(*model.VolumeSnapshotSpec)
+		if ok {
+			snps = append(snps, p)
+		}
+	}
 	p := c.ParameterFilter(m, len(snps), []string{"ID", "VOLUMEID", "STATUS", "USERID", "PROJECTID"})
 
 	return c.SortSnapshots(snps, p)[p.beginIdx:p.endIdx], nil

--- a/pkg/db/drivers/etcd/etcd.go
+++ b/pkg/db/drivers/etcd/etcd.go
@@ -62,13 +62,13 @@ const (
 
 var sortableKeysMap = map[string][]string{
 	typeFileShares:         {"ID", "NAME", "STATUS", "AVAILABILITYZONE", "PROFILEID", "TENANTID", "SIZE", "POOLID", "DESCRIPTION"},
-	typeFileShareSnapshots: {"ID", "VOLUMEID", "STATUS", "USERID", "TENANTID", "SIZE"},
+	typeFileShareSnapshots: {"ID", "NAME", "VOLUMEID", "STATUS", "USERID", "TENANTID", "SIZE"},
 	typeDocks:              {"ID", "NAME", "STATUS", "ENDPOINT", "DRIVERNAME", "DESCRIPTION"},
 	typePools:              {"ID", "NAME", "STATUS", "AVAILABILITYZONE", "DOCKID"},
 	typeProfiles:           {"ID", "NAME", "DESCRIPTION"},
 	typeVolumes:            {"ID", "NAME", "STATUS", "AVAILABILITYZONE", "PROFILEID", "TENANTID", "SIZE", "POOLID", "DESCRIPTION", "GROUPID"},
 	typeAttachments:        {"ID", "VOLUMEID", "STATUS", "USERID", "TENANTID", "SIZE"},
-	typeVolumeSnapshots:    {"ID", "VOLUMEID", "STATUS", "USERID", "TENANTID", "SIZE"},
+	typeVolumeSnapshots:    {"ID", "NAME", "VOLUMEID", "STATUS", "USERID", "TENANTID", "SIZE"},
 }
 
 func IsAdminContext(ctx *c.Context) bool {

--- a/pkg/db/drivers/etcd/etcd_test.go
+++ b/pkg/db/drivers/etcd/etcd_test.go
@@ -614,3 +614,791 @@ func TestUpdateFileShareAcl(t *testing.T) {
 		t.Errorf("Expected %+v, got %+v\n", "081071b1-01bd-49ad-80dd-c2aa795f1d15", manilaAclId)
 	}
 }
+
+func TestFilterAndSort(t *testing.T) {
+	// Use a specific type(pool) to test unit test
+	type test struct {
+		input    []*model.StoragePoolSpec
+		param    map[string][]string
+		expected []*model.StoragePoolSpec
+	}
+	tests := []test{
+		// select by storage type
+		{
+			input: []*model.StoragePoolSpec{
+				&SamplePools[0],
+				&SamplePools[1],
+				&SamplePools[2],
+			},
+			param: map[string][]string{
+				"storageType": {"block"},
+			},
+			expected: []*model.StoragePoolSpec{
+				&SamplePools[0],
+				&SamplePools[1],
+			},
+		},
+		// sort by name asc
+		{
+			input: []*model.StoragePoolSpec{
+				&SamplePools[0],
+				&SamplePools[1],
+				&SamplePools[2],
+			},
+			param: map[string][]string{
+				"sortKey": {"name"},
+				"sortDir": {"asc"},
+			},
+			expected: []*model.StoragePoolSpec{
+				&SamplePools[2],
+				&SamplePools[0],
+				&SamplePools[1],
+			},
+		},
+		// sort by name desc
+		{
+			input: []*model.StoragePoolSpec{
+				&SamplePools[0],
+				&SamplePools[1],
+				&SamplePools[2],
+			},
+			param: map[string][]string{
+				"sortKey": {"name"},
+				"sortDir": {"desc"},
+			},
+			expected: []*model.StoragePoolSpec{
+				&SamplePools[1],
+				&SamplePools[0],
+				&SamplePools[2],
+			},
+		},
+		// limit is 2
+		{
+			input: []*model.StoragePoolSpec{
+				&SamplePools[0],
+				&SamplePools[1],
+				&SamplePools[2],
+			},
+			param: map[string][]string{
+				"limit":  {"2"},
+				"offset": {"1"},
+			},
+			expected: []*model.StoragePoolSpec{
+				&SamplePools[1],
+				&SamplePools[2],
+			},
+		},
+	}
+	for _, testcase := range tests {
+		ret := fc.FilterAndSort(testcase.input, testcase.param, sortableKeysMap[typePools])
+		var res = []*model.StoragePoolSpec{}
+		for _, data := range ret.([]interface{}) {
+			res = append(res, data.(*model.StoragePoolSpec))
+		}
+		if !reflect.DeepEqual(res, testcase.expected) {
+			var expected []model.StoragePoolSpec
+			for _, value := range testcase.expected {
+				expected = append(expected, *value)
+			}
+			var got []model.StoragePoolSpec
+			for _, value := range res {
+				got = append(got, *value)
+			}
+			t.Errorf("Expected %+v\n", expected)
+			t.Errorf("Got %+v\n", got)
+		}
+	}
+}
+
+func TestListFileSharesWithFilter(t *testing.T) {
+	type test struct {
+		input    []*model.FileShareSpec
+		param    map[string][]string
+		expected []*model.FileShareSpec
+	}
+	tests := []test{
+		// select by storage type
+		{
+			input: []*model.FileShareSpec{
+				&SampleFileShares[0],
+				&SampleFileShares[1],
+			},
+			param: map[string][]string{
+				"poolId": {"a5965ebe-dg2c-434t-b28e-f373746a71ca"},
+			},
+			expected: []*model.FileShareSpec{
+				&SampleFileShares[0],
+			},
+		},
+		// sort by name asc
+		{
+			input: []*model.FileShareSpec{
+				&SampleFileShares[0],
+				&SampleFileShares[1],
+			},
+			param: map[string][]string{
+				"sortKey": {"name"},
+				"sortDir": {"asc"},
+			},
+			expected: []*model.FileShareSpec{
+				&SampleFileShares[0],
+				&SampleFileShares[1],
+			},
+		},
+		// sort by name desc
+		{
+			input: []*model.FileShareSpec{
+				&SampleFileShares[0],
+				&SampleFileShares[1],
+			},
+			param: map[string][]string{
+				"sortKey": {"name"},
+				"sortDir": {"desc"},
+			},
+			expected: []*model.FileShareSpec{
+				&SampleFileShares[1],
+				&SampleFileShares[0],
+			},
+		},
+		// limit is 1
+		{
+			input: []*model.FileShareSpec{
+				&SampleFileShares[0],
+				&SampleFileShares[1]},
+			param: map[string][]string{
+				"limit":  {"1"},
+				"offset": {"1"},
+			},
+			expected: []*model.FileShareSpec{
+				&SampleFileShares[1],
+			},
+		},
+	}
+	for _, testcase := range tests {
+		ret := fc.FilterAndSort(testcase.input, testcase.param, sortableKeysMap[typeFileShares])
+		var res = []*model.FileShareSpec{}
+		for _, data := range ret.([]interface{}) {
+			res = append(res, data.(*model.FileShareSpec))
+		}
+		if !reflect.DeepEqual(res, testcase.expected) {
+			var expected []model.FileShareSpec
+			for _, value := range testcase.expected {
+				expected = append(expected, *value)
+			}
+			var got []model.FileShareSpec
+			for _, value := range res {
+				got = append(got, *value)
+			}
+			t.Errorf("Expected %+v\n", expected)
+			t.Errorf("Got %+v\n", got)
+		}
+	}
+}
+func TestListFileShareSnapshotsWithFilter(t *testing.T) {
+	type test struct {
+		input    []*model.FileShareSnapshotSpec
+		param    map[string][]string
+		expected []*model.FileShareSnapshotSpec
+	}
+	tests := []test{
+		// select by storage type
+		{
+			input: []*model.FileShareSnapshotSpec{
+				&SampleFileShareSnapshots[0],
+				&SampleFileShareSnapshots[1],
+			},
+			param: map[string][]string{
+				"status": {"error"},
+			},
+			expected: []*model.FileShareSnapshotSpec{},
+		},
+		// sort by name asc
+		{
+			input: []*model.FileShareSnapshotSpec{
+				&SampleFileShareSnapshots[0],
+				&SampleFileShareSnapshots[1],
+			},
+			param: map[string][]string{
+				"sortKey": {"name"},
+				"sortDir": {"asc"},
+			},
+			expected: []*model.FileShareSnapshotSpec{
+				&SampleFileShareSnapshots[0],
+				&SampleFileShareSnapshots[1],
+			},
+		},
+		// sort by name desc
+		{
+			input: []*model.FileShareSnapshotSpec{
+				&SampleFileShareSnapshots[0],
+				&SampleFileShareSnapshots[1],
+			},
+			param: map[string][]string{
+				"sortKey": {"name"},
+				"sortDir": {"desc"},
+			},
+			expected: []*model.FileShareSnapshotSpec{
+				&SampleFileShareSnapshots[1],
+				&SampleFileShareSnapshots[0],
+			},
+		},
+		// limit is 1
+		{
+			input: []*model.FileShareSnapshotSpec{
+				&SampleFileShareSnapshots[0],
+				&SampleFileShareSnapshots[1]},
+			param: map[string][]string{
+				"limit":  {"1"},
+				"offset": {"1"},
+			},
+			expected: []*model.FileShareSnapshotSpec{
+				&SampleFileShareSnapshots[1],
+			},
+		},
+	}
+	for _, testcase := range tests {
+		ret := fc.FilterAndSort(testcase.input, testcase.param, sortableKeysMap[typeFileShareSnapshots])
+		var res = []*model.FileShareSnapshotSpec{}
+		for _, data := range ret.([]interface{}) {
+			res = append(res, data.(*model.FileShareSnapshotSpec))
+		}
+		if !reflect.DeepEqual(res, testcase.expected) {
+			var expected []model.FileShareSnapshotSpec
+			for _, value := range testcase.expected {
+				expected = append(expected, *value)
+			}
+			var got []model.FileShareSnapshotSpec
+			for _, value := range res {
+				got = append(got, *value)
+			}
+			t.Errorf("Expected %+v\n", expected)
+			t.Errorf("Got %+v\n", got)
+		}
+	}
+}
+func TestListDocksWithFilter(t *testing.T) {
+	type test struct {
+		input    []*model.DockSpec
+		param    map[string][]string
+		expected []*model.DockSpec
+	}
+	tests := []test{
+		// select by storage type
+		{
+			input: []*model.DockSpec{
+				&SampleMultiDocks[0],
+				&SampleMultiDocks[1],
+				&SampleMultiDocks[2],
+			},
+			param: map[string][]string{
+				"driverName": {"cinder"},
+			},
+			expected: []*model.DockSpec{
+				&SampleMultiDocks[1],
+			},
+		},
+		// sort by name asc
+		{
+			input: []*model.DockSpec{
+				&SampleMultiDocks[0],
+				&SampleMultiDocks[1],
+				&SampleMultiDocks[2],
+			},
+			param: map[string][]string{
+				"sortKey": {"name"},
+				"sortDir": {"asc"},
+			},
+			expected: []*model.DockSpec{
+				&SampleMultiDocks[0],
+				&SampleMultiDocks[2],
+				&SampleMultiDocks[1],
+			},
+		},
+		// sort by name desc
+		{
+			input: []*model.DockSpec{
+				&SampleMultiDocks[0],
+				&SampleMultiDocks[1],
+				&SampleMultiDocks[2],
+			},
+			param: map[string][]string{
+				"sortKey": {"name"},
+				"sortDir": {"desc"},
+			},
+			expected: []*model.DockSpec{
+				&SampleMultiDocks[1],
+				&SampleMultiDocks[2],
+				&SampleMultiDocks[0],
+			},
+		},
+		// limit is 1
+		{
+			input: []*model.DockSpec{
+				&SampleMultiDocks[0],
+				&SampleMultiDocks[1]},
+			param: map[string][]string{
+				"limit":  {"1"},
+				"offset": {"1"},
+			},
+			expected: []*model.DockSpec{
+				&SampleMultiDocks[1],
+			},
+		},
+	}
+	for _, testcase := range tests {
+		ret := fc.FilterAndSort(testcase.input, testcase.param, sortableKeysMap[typeFileShareSnapshots])
+		var res = []*model.DockSpec{}
+		for _, data := range ret.([]interface{}) {
+			res = append(res, data.(*model.DockSpec))
+		}
+		if !reflect.DeepEqual(res, testcase.expected) {
+			var expected []model.DockSpec
+			for _, value := range testcase.expected {
+				expected = append(expected, *value)
+			}
+			var got []model.DockSpec
+			for _, value := range res {
+				got = append(got, *value)
+			}
+			t.Errorf("Expected %+v\n", expected)
+			t.Errorf("Got %+v\n", got)
+		}
+	}
+}
+
+func TestListPoolsWithFilter(t *testing.T) {
+	type test struct {
+		input    []*model.StoragePoolSpec
+		param    map[string][]string
+		expected []*model.StoragePoolSpec
+	}
+	tests := []test{
+		// select by storage type
+		{
+			input: []*model.StoragePoolSpec{
+				&SamplePools[0],
+				&SamplePools[1],
+				&SamplePools[2],
+			},
+			param: map[string][]string{
+				"storageType": {"block"},
+			},
+			expected: []*model.StoragePoolSpec{
+				&SamplePools[0],
+				&SamplePools[1],
+			},
+		},
+		// sort by name asc
+		{
+			input: []*model.StoragePoolSpec{
+				&SamplePools[0],
+				&SamplePools[1],
+				&SamplePools[2],
+			},
+			param: map[string][]string{
+				"sortKey": {"name"},
+				"sortDir": {"asc"},
+			},
+			expected: []*model.StoragePoolSpec{
+				&SamplePools[2],
+				&SamplePools[0],
+				&SamplePools[1],
+			},
+		},
+		// sort by name desc
+		{
+			input: []*model.StoragePoolSpec{
+				&SamplePools[0],
+				&SamplePools[1],
+				&SamplePools[2],
+			},
+			param: map[string][]string{
+				"sortKey": {"name"},
+				"sortDir": {"desc"},
+			},
+			expected: []*model.StoragePoolSpec{
+				&SamplePools[1],
+				&SamplePools[0],
+				&SamplePools[2],
+			},
+		},
+		// limit is 2
+		{
+			input: []*model.StoragePoolSpec{
+				&SamplePools[0],
+				&SamplePools[1],
+				&SamplePools[2],
+			},
+			param: map[string][]string{
+				"limit":  {"2"},
+				"offset": {"1"},
+			},
+			expected: []*model.StoragePoolSpec{
+				&SamplePools[1],
+				&SamplePools[2],
+			},
+		},
+	}
+	for _, testcase := range tests {
+		ret := fc.FilterAndSort(testcase.input, testcase.param, sortableKeysMap[typePools])
+		var res = []*model.StoragePoolSpec{}
+		for _, data := range ret.([]interface{}) {
+			res = append(res, data.(*model.StoragePoolSpec))
+		}
+		if !reflect.DeepEqual(res, testcase.expected) {
+			var expected []model.StoragePoolSpec
+			for _, value := range testcase.expected {
+				expected = append(expected, *value)
+			}
+			var got []model.StoragePoolSpec
+			for _, value := range res {
+				got = append(got, *value)
+			}
+			t.Errorf("Expected %+v\n", expected)
+			t.Errorf("Got %+v\n", got)
+		}
+	}
+}
+
+func TestListProfilesWithFilter(t *testing.T) {
+	type test struct {
+		input    []*model.ProfileSpec
+		param    map[string][]string
+		expected []*model.ProfileSpec
+	}
+	tests := []test{
+		// select by storage type
+		{
+			input: []*model.ProfileSpec{
+				&SampleProfiles[0],
+				&SampleProfiles[1],
+			},
+			param: map[string][]string{
+				"description": {"silver policy"},
+			},
+			expected: []*model.ProfileSpec{
+				&SampleProfiles[1],
+			},
+		},
+		// sort by name asc
+		{
+			input: []*model.ProfileSpec{
+				&SampleProfiles[0],
+				&SampleProfiles[1],
+			},
+			param: map[string][]string{
+				"sortKey": {"name"},
+				"sortDir": {"asc"},
+			},
+			expected: []*model.ProfileSpec{
+				&SampleProfiles[0],
+				&SampleProfiles[1],
+			},
+		},
+		// sort by name desc
+		{
+			input: []*model.ProfileSpec{
+				&SampleProfiles[0],
+				&SampleProfiles[1],
+			},
+			param: map[string][]string{
+				"sortKey": {"name"},
+				"sortDir": {"desc"},
+			},
+			expected: []*model.ProfileSpec{
+				&SampleProfiles[1],
+				&SampleProfiles[0],
+			},
+		},
+		// limit is 1
+		{
+			input: []*model.ProfileSpec{
+				&SampleProfiles[0],
+				&SampleProfiles[1],
+			},
+			param: map[string][]string{
+				"limit":  {"1"},
+				"offset": {"1"},
+			},
+			expected: []*model.ProfileSpec{
+				&SampleProfiles[1],
+			},
+		},
+	}
+	for _, testcase := range tests {
+		ret := fc.FilterAndSort(testcase.input, testcase.param, sortableKeysMap[typeProfiles])
+		var res = []*model.ProfileSpec{}
+		for _, data := range ret.([]interface{}) {
+			res = append(res, data.(*model.ProfileSpec))
+		}
+		if !reflect.DeepEqual(res, testcase.expected) {
+			var expected []model.ProfileSpec
+			for _, value := range testcase.expected {
+				expected = append(expected, *value)
+			}
+			var got []model.ProfileSpec
+			for _, value := range res {
+				got = append(got, *value)
+			}
+			t.Errorf("Expected %+v\n", expected)
+			t.Errorf("Got %+v\n", got)
+		}
+	}
+}
+
+func TestListVolumesWithFilter(t *testing.T) {
+	type test struct {
+		input    []*model.VolumeSpec
+		param    map[string][]string
+		expected []*model.VolumeSpec
+	}
+	tests := []test{
+		// select by storage type
+		{
+			input: []*model.VolumeSpec{
+				&SampleMultiVolumes[0],
+				&SampleMultiVolumes[1],
+			},
+			param: map[string][]string{
+				"size": {"1"},
+			},
+			expected: []*model.VolumeSpec{
+				&SampleMultiVolumes[1],
+			},
+		},
+		// sort by name asc
+		{
+			input: []*model.VolumeSpec{
+				&SampleMultiVolumes[0],
+				&SampleMultiVolumes[1],
+			},
+			param: map[string][]string{
+				"sortKey": {"name"},
+				"sortDir": {"asc"},
+			},
+			expected: []*model.VolumeSpec{
+				&SampleMultiVolumes[0],
+				&SampleMultiVolumes[1],
+			},
+		},
+		// sort by name desc
+		{
+			input: []*model.VolumeSpec{
+				&SampleMultiVolumes[0],
+				&SampleMultiVolumes[1],
+			},
+			param: map[string][]string{
+				"sortKey": {"name"},
+				"sortDir": {"desc"},
+			},
+			expected: []*model.VolumeSpec{
+				&SampleMultiVolumes[1],
+				&SampleMultiVolumes[0],
+			},
+		},
+		// limit is 1
+		{
+			input: []*model.VolumeSpec{
+				&SampleMultiVolumes[0],
+				&SampleMultiVolumes[1],
+			},
+			param: map[string][]string{
+				"limit":  {"1"},
+				"offset": {"1"},
+			},
+			expected: []*model.VolumeSpec{
+				&SampleMultiVolumes[1],
+			},
+		},
+	}
+	for _, testcase := range tests {
+		ret := fc.FilterAndSort(testcase.input, testcase.param, sortableKeysMap[typeVolumes])
+		var res = []*model.VolumeSpec{}
+		for _, data := range ret.([]interface{}) {
+			res = append(res, data.(*model.VolumeSpec))
+		}
+		if !reflect.DeepEqual(res, testcase.expected) {
+			var expected []model.VolumeSpec
+			for _, value := range testcase.expected {
+				expected = append(expected, *value)
+			}
+			var got []model.VolumeSpec
+			for _, value := range res {
+				got = append(got, *value)
+			}
+			t.Errorf("Expected %+v\n", expected)
+			t.Errorf("Got %+v\n", got)
+		}
+	}
+}
+func TestListVolumeAttachmentsWithFilter(t *testing.T) {
+	type test struct {
+		input    []*model.VolumeAttachmentSpec
+		param    map[string][]string
+		expected []*model.VolumeAttachmentSpec
+	}
+	tests := []test{
+		// select by storage type
+		{
+			input: []*model.VolumeAttachmentSpec{
+				&SampleMultiAttachments[0],
+				&SampleMultiAttachments[1],
+			},
+			param: map[string][]string{
+				"status": {"attached"},
+			},
+			expected: []*model.VolumeAttachmentSpec{
+				&SampleMultiAttachments[1],
+			},
+		},
+		// sort by volume id asc
+		{
+			input: []*model.VolumeAttachmentSpec{
+				&SampleMultiAttachments[0],
+				&SampleMultiAttachments[1],
+			},
+			param: map[string][]string{
+				"sortKey": {"volumeId"},
+				"sortDir": {"asc"},
+			},
+			expected: []*model.VolumeAttachmentSpec{
+				&SampleMultiAttachments[0],
+				&SampleMultiAttachments[1],
+			},
+		},
+		// sort by volume id desc
+		{
+			input: []*model.VolumeAttachmentSpec{
+				&SampleMultiAttachments[0],
+				&SampleMultiAttachments[1],
+			},
+			param: map[string][]string{
+				"sortKey": {"volumeId"},
+				"sortDir": {"desc"},
+			},
+			expected: []*model.VolumeAttachmentSpec{
+				&SampleMultiAttachments[1],
+				&SampleMultiAttachments[0],
+			},
+		},
+		// limit is 1
+		{
+			input: []*model.VolumeAttachmentSpec{
+				&SampleMultiAttachments[0],
+				&SampleMultiAttachments[1],
+			},
+			param: map[string][]string{
+				"limit":  {"1"},
+				"offset": {"1"},
+			},
+			expected: []*model.VolumeAttachmentSpec{
+				&SampleMultiAttachments[1],
+			},
+		},
+	}
+	for _, testcase := range tests {
+		ret := fc.FilterAndSort(testcase.input, testcase.param, sortableKeysMap[typeAttachments])
+		var res = []*model.VolumeAttachmentSpec{}
+		for _, data := range ret.([]interface{}) {
+			res = append(res, data.(*model.VolumeAttachmentSpec))
+		}
+		if !reflect.DeepEqual(res, testcase.expected) {
+			var expected []model.VolumeAttachmentSpec
+			for _, value := range testcase.expected {
+				expected = append(expected, *value)
+			}
+			var got []model.VolumeAttachmentSpec
+			for _, value := range res {
+				got = append(got, *value)
+			}
+			t.Errorf("Expected %+v\n", expected)
+			t.Errorf("Got %+v\n", got)
+		}
+	}
+}
+func TestListVolumeSnapshotsWithFilter(t *testing.T) {
+	type test struct {
+		input    []*model.VolumeSnapshotSpec
+		param    map[string][]string
+		expected []*model.VolumeSnapshotSpec
+	}
+	tests := []test{
+		// select by storage type
+		{
+			input: []*model.VolumeSnapshotSpec{
+				&SampleSnapshots[0],
+				&SampleSnapshots[1],
+			},
+			param: map[string][]string{
+				"status": {"available"},
+			},
+			expected: []*model.VolumeSnapshotSpec{
+				&SampleSnapshots[0],
+				&SampleSnapshots[1],
+			},
+		},
+		// sort by name asc
+		{
+			input: []*model.VolumeSnapshotSpec{
+				&SampleSnapshots[0],
+				&SampleSnapshots[1],
+			},
+			param: map[string][]string{
+				"sortKey": {"name"},
+				"sortDir": {"asc"},
+			},
+			expected: []*model.VolumeSnapshotSpec{
+				&SampleSnapshots[0],
+				&SampleSnapshots[1],
+			},
+		},
+		// sort by name desc
+		{
+			input: []*model.VolumeSnapshotSpec{
+				&SampleSnapshots[0],
+				&SampleSnapshots[1],
+			},
+			param: map[string][]string{
+				"sortKey": {"name"},
+				"sortDir": {"desc"},
+			},
+			expected: []*model.VolumeSnapshotSpec{
+				&SampleSnapshots[1],
+				&SampleSnapshots[0],
+			},
+		},
+		// limit is 1
+		{
+			input: []*model.VolumeSnapshotSpec{
+				&SampleSnapshots[0],
+				&SampleSnapshots[1],
+			},
+			param: map[string][]string{
+				"limit":  {"1"},
+				"offset": {"1"},
+			},
+			expected: []*model.VolumeSnapshotSpec{
+				&SampleSnapshots[1],
+			},
+		},
+	}
+	for _, testcase := range tests {
+		ret := fc.FilterAndSort(testcase.input, testcase.param, sortableKeysMap[typePools])
+		var res = []*model.VolumeSnapshotSpec{}
+		for _, data := range ret.([]interface{}) {
+			res = append(res, data.(*model.VolumeSnapshotSpec))
+		}
+		if !reflect.DeepEqual(res, testcase.expected) {
+			var expected []model.VolumeSnapshotSpec
+			for _, value := range testcase.expected {
+				expected = append(expected, *value)
+			}
+			var got []model.VolumeSnapshotSpec
+			for _, value := range res {
+				got = append(got, *value)
+			}
+			t.Errorf("Expected %+v\n", expected)
+			t.Errorf("Got %+v\n", got)
+		}
+	}
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/opensds/opensds/pkg/utils/constants"
 
@@ -326,4 +327,11 @@ func WaitForCondition(f func() (bool, error), interval, timeout time.Duration) e
 		time.Sleep(interval - elapsed)
 	}
 	return fmt.Errorf("wait for condition timeout")
+}
+
+func LowerCaseFirst(str string) string {
+	for i, v := range str {
+		return string(unicode.ToLower(v)) + str[i+1:]
+	}
+	return ""
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -24,7 +24,6 @@ import (
 	"sort"
 	"strings"
 	"time"
-	"unicode"
 
 	"github.com/opensds/opensds/pkg/utils/constants"
 
@@ -329,9 +328,11 @@ func WaitForCondition(f func() (bool, error), interval, timeout time.Duration) e
 	return fmt.Errorf("wait for condition timeout")
 }
 
-func LowerCaseFirst(str string) string {
-	for i, v := range str {
-		return string(unicode.ToLower(v)) + str[i+1:]
+func ContainsIgnoreCase(a []string, x string) bool {
+	for _, n := range a {
+		if strings.EqualFold(x, n) {
+			return true
+		}
 	}
-	return ""
+	return false
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -500,3 +500,14 @@ func TestSlice(t *testing.T) {
 
 	}
 }
+
+func TestLowerCaseFirst(t *testing.T) {
+	input := []string{"Name", "NAME", "name"}
+	expected := []string{"name", "nAME", "name"}
+	for index := range input {
+		result := LowerCaseFirst(input[index])
+		if expected[index] != result {
+			t.Errorf("Expected %v, get %v", expected[index], result)
+		}
+	}
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -501,13 +501,26 @@ func TestSlice(t *testing.T) {
 	}
 }
 
-func TestLowerCaseFirst(t *testing.T) {
-	input := []string{"Name", "NAME", "name"}
-	expected := []string{"name", "nAME", "name"}
-	for index := range input {
-		result := LowerCaseFirst(input[index])
-		if expected[index] != result {
-			t.Errorf("Expected %v, get %v", expected[index], result)
-		}
+func TestContainsIgnoreCase(t *testing.T) {
+	var permissions = []string{"Read", "Write", "Execute"}
+	var testkey1 = "READ"
+	var testkey2 = "Read"
+	var testkey3 = "read"
+	var testkey4 = "Raed"
+	contains := ContainsIgnoreCase(permissions, testkey1)
+	if contains != true {
+		t.Errorf("%v should contains %v", permissions, testkey1)
+	}
+	contains = ContainsIgnoreCase(permissions, testkey2)
+	if contains != true {
+		t.Errorf("%v should contains %v", permissions, testkey2)
+	}
+	contains = ContainsIgnoreCase(permissions, testkey3)
+	if contains != true {
+		t.Errorf("%v should contains %v", permissions, testkey3)
+	}
+	contains = ContainsIgnoreCase(permissions, testkey4)
+	if contains != false {
+		t.Errorf("%v shouldn't contains %v", permissions, testkey4)
 	}
 }

--- a/testutils/collection/data.go
+++ b/testutils/collection/data.go
@@ -123,6 +123,39 @@ var (
 		},
 	}
 
+	SampleMultiDocks = []model.DockSpec{
+		{
+			BaseModel: &model.BaseModel{
+				Id: "b7602e18-771e-11e7-8f38-dbd6d291f4e0",
+			},
+			Name:        "sample-dock-01",
+			Description: "sample backend service",
+			Endpoint:    "localhost:50050",
+			DriverName:  "sample",
+			Type:        model.DockTypeProvioner,
+		},
+		{
+			BaseModel: &model.BaseModel{
+				Id: "a594b8ac-a103-11e7-985f-d723bcf01b5f",
+			},
+			Name:        "sample-dock-03",
+			Description: "sample backend service",
+			Endpoint:    "localhost:50050",
+			DriverName:  "cinder",
+			Type:        model.DockTypeProvioner,
+		},
+		{
+			BaseModel: &model.BaseModel{
+				Id: "bdd44c8e-b8a9-488a-89c0-d1e5beb902dg",
+			},
+			Name:        "sample-dock-02",
+			Description: "sample backend service",
+			Endpoint:    "localhost:50050",
+			DriverName:  "ceph",
+			Type:        model.DockTypeProvioner,
+		},
+	}
+
 	SamplePools = []model.StoragePoolSpec{
 		{
 			BaseModel: &model.BaseModel{
@@ -344,6 +377,35 @@ var (
 		},
 	}
 
+	SampleMultiVolumes = []model.VolumeSpec{
+		{
+			BaseModel: &model.BaseModel{
+				Id: "bd5b12a8-a101-11e7-941e-d77981b584d8",
+			},
+			Name:             "sample-volume-01",
+			Description:      "This is a sample volume for testing",
+			AvailabilityZone: "default",
+			Size:             int64(2),
+			Status:           "available",
+			PoolId:           "084bf71e-a102-11e7-88a8-e31fe6d52248",
+			ProfileId:        "1106b972-66ef-11e7-b172-db03f3689c9c",
+			SnapshotId:       "",
+		},
+		{
+			BaseModel: &model.BaseModel{
+				Id: "bd5b12a8-a101-11e7-941e-d77981b584d8",
+			},
+			Name:             "sample-volume-02",
+			AvailabilityZone: "default",
+			Description:      "This is a sample volume for testing",
+			Size:             int64(1),
+			Status:           "available",
+			PoolId:           "084bf71e-a102-11e7-88a8-e31fe6d52248",
+			ProfileId:        "1106b972-66ef-11e7-b172-db03f3689c9c",
+			SnapshotId:       "3769855c-a102-11e7-b772-17b880d2f537",
+		},
+	}
+
 	SampleShareNames = []string{}
 
 	SampleShares = []model.FileShareSpec{
@@ -390,6 +452,43 @@ var (
 			},
 			Status:   "available",
 			VolumeId: "bd5b12a8-a101-11e7-941e-d77981b584d8",
+			HostId:   "202964b5-8e73-46fd-b41b-a8e403f3c30b",
+			ConnectionInfo: model.ConnectionInfo{
+				DriverVolumeType: "iscsi",
+				ConnectionData: map[string]interface{}{
+					"targetDiscovered": true,
+					"targetIqn":        "iqn.2017-10.io.opensds:volume:00000001",
+					"targetPortal":     "127.0.0.0.1:3260",
+					"discard":          false,
+				},
+			},
+		},
+	}
+
+	SampleMultiAttachments = []model.VolumeAttachmentSpec{
+		{
+			BaseModel: &model.BaseModel{
+				Id: "f2dda3d2-bf79-11e7-8665-f750b088f63e",
+			},
+			Status:   "available",
+			VolumeId: "bd5b12a8-a101-11e7-941e-d77981b584d8",
+			HostId:   "202964b5-8e73-46fd-b41b-a8e403f3c30b",
+			ConnectionInfo: model.ConnectionInfo{
+				DriverVolumeType: "iscsi",
+				ConnectionData: map[string]interface{}{
+					"targetDiscovered": true,
+					"targetIqn":        "iqn.2017-10.io.opensds:volume:00000001",
+					"targetPortal":     "127.0.0.0.1:3260",
+					"discard":          false,
+				},
+			},
+		},
+		{
+			BaseModel: &model.BaseModel{
+				Id: "3769855c-a102-11e7-b772-17b880d2f537",
+			},
+			Status:   "attached",
+			VolumeId: "bd5b12a8-a101-11e7-941e-d77981b584d9",
 			HostId:   "202964b5-8e73-46fd-b41b-a8e403f3c30b",
 			ConnectionInfo: model.ConnectionInfo{
 				DriverVolumeType: "iscsi",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Nowadays, each type of source has its own select function, like"SelectFileShares", "SelectFileShareSnapshots", "SelectPools", "SelectDocks", and so on.
Each of the select function almost do the same things, and the only difference is that the data type which they selected is different.
I write a function to select all the type of source to avoid shotgun surgery when we need to maintain the select function.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 

**Special notes for your reviewer**:
This pr integrate all the "select" function(like SelectPools, SelectDocks, SelectProfiles...) to one.
And next step, I want to integrate all the "sort" function(like SortPools, SortDocks, SortProfiles).

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Unit Test:
......
=== RUN   TestFilterAndSort
--- PASS: TestFilterAndSort (0.00s)
=== RUN   TestListFileSharesWithFilter
--- PASS: TestListFileSharesWithFilter (0.00s)
=== RUN   TestListFileShareSnapshotsWithFilter
--- PASS: TestListFileShareSnapshotsWithFilter (0.00s)
=== RUN   TestListDocksWithFilter
--- PASS: TestListDocksWithFilter (0.00s)
=== RUN   TestListPoolsWithFilter
--- PASS: TestListPoolsWithFilter (0.00s)
=== RUN   TestListProfilesWithFilter
--- PASS: TestListProfilesWithFilter (0.00s)
=== RUN   TestListVolumesWithFilter
--- PASS: TestListVolumesWithFilter (0.00s)
=== RUN   TestListVolumeAttachmentsWithFilter
--- PASS: TestListVolumeAttachmentsWithFilter (0.00s)
=== RUN   TestListVolumeSnapshotsWithFilter
--- PASS: TestListVolumeSnapshotsWithFilter (0.00s)
PASS
coverage: 32.2% of statements
ok      github.com/opensds/opensds/pkg/db/drivers/etcd  (cached)        coverage: 32.2% of statements

Test with pool list:
root@node01:~/gopath/src/github.com/opensds/opensds (development) # ./build/out/bin/osdsctl pool list
WARNING: OPENSDS_ENDPOINT is not specified, use default(http://localhost:50040)
WARNING: Not found Env OPENSDS_AUTH_STRATEGY, use default(noauth)
+--------------------------------------+-------------------------+-------------+-----------+---------------+--------------+
| Id                                   | Name                    | Description | Status    | TotalCapacity | FreeCapacity |
+--------------------------------------+-------------------------+-------------+-----------+---------------+--------------+
| 47d06aef-afe0-5f34-90c1-66c355662a9b | opensds-volumes-default |             | available | 20            | 20           |
| 157e862c-7604-5d1b-b80a-37559a88e65d | opensds-files-default   |             | available | 20            | 20           |
+--------------------------------------+-------------------------+-------------+-----------+---------------+--------------+
root@node01:~/gopath/src/github.com/opensds/opensds (development) # ./build/out/bin/osdsctl pool list --sortKey name --sortDir asc
WARNING: OPENSDS_ENDPOINT is not specified, use default(http://localhost:50040)
WARNING: Not found Env OPENSDS_AUTH_STRATEGY, use default(noauth)
+--------------------------------------+-------------------------+-------------+-----------+---------------+--------------+
| Id                                   | Name                    | Description | Status    | TotalCapacity | FreeCapacity |
+--------------------------------------+-------------------------+-------------+-----------+---------------+--------------+
| 157e862c-7604-5d1b-b80a-37559a88e65d | opensds-files-default   |             | available | 20            | 20           |
| 47d06aef-afe0-5f34-90c1-66c355662a9b | opensds-volumes-default |             | available | 20            | 20           |
+--------------------------------------+-------------------------+-------------+-----------+---------------+--------------+
root@node01:~/gopath/src/github.com/opensds/opensds (development) # ./build/out/bin/osdsctl pool list --sortKey name --sortDir desc
WARNING: OPENSDS_ENDPOINT is not specified, use default(http://localhost:50040)
WARNING: Not found Env OPENSDS_AUTH_STRATEGY, use default(noauth)
+--------------------------------------+-------------------------+-------------+-----------+---------------+--------------+
| Id                                   | Name                    | Description | Status    | TotalCapacity | FreeCapacity |
+--------------------------------------+-------------------------+-------------+-----------+---------------+--------------+
| 47d06aef-afe0-5f34-90c1-66c355662a9b | opensds-volumes-default |             | available | 20            | 20           |
| 157e862c-7604-5d1b-b80a-37559a88e65d | opensds-files-default   |             | available | 20            | 20           |
+--------------------------------------+-------------------------+-------------+-----------+---------------+--------------+
root@node01:~/gopath/src/github.com/opensds/opensds (development) # ./build/out/bin/osdsctl pool list --name opensds-volumes-default
WARNING: OPENSDS_ENDPOINT is not specified, use default(http://localhost:50040)
WARNING: Not found Env OPENSDS_AUTH_STRATEGY, use default(noauth)
+--------------------------------------+-------------------------+-------------+-----------+---------------+--------------+
| Id                                   | Name                    | Description | Status    | TotalCapacity | FreeCapacity |
+--------------------------------------+-------------------------+-------------+-----------+---------------+--------------+
| 47d06aef-afe0-5f34-90c1-66c355662a9b | opensds-volumes-default |             | available | 20            | 20           |
+--------------------------------------+-------------------------+-------------+-----------+---------------+--------------+
root@node01:~/gopath/src/github.com/opensds/opensds (development) # ./build/out/bin/osdsctl pool list --id 157e862c-7604-5d1b-b80a-37559a88e65d
WARNING: OPENSDS_ENDPOINT is not specified, use default(http://localhost:50040)
WARNING: Not found Env OPENSDS_AUTH_STRATEGY, use default(noauth)
+--------------------------------------+-----------------------+-------------+-----------+---------------+--------------+
| Id                                   | Name                  | Description | Status    | TotalCapacity | FreeCapacity |
+--------------------------------------+-----------------------+-------------+-----------+---------------+--------------+
| 157e862c-7604-5d1b-b80a-37559a88e65d | opensds-files-default |             | available | 20            | 20           |
+--------------------------------------+-----------------------+-------------+-----------+---------------+--------------+
root@node01:~/gopath/src/github.com/opensds/opensds (development) # ./build/out/bin/osdsctl pool list --status available
WARNING: OPENSDS_ENDPOINT is not specified, use default(http://localhost:50040)
WARNING: Not found Env OPENSDS_AUTH_STRATEGY, use default(noauth)
+--------------------------------------+-------------------------+-------------+-----------+---------------+--------------+
| Id                                   | Name                    | Description | Status    | TotalCapacity | FreeCapacity |
+--------------------------------------+-------------------------+-------------+-----------+---------------+--------------+
| 47d06aef-afe0-5f34-90c1-66c355662a9b | opensds-volumes-default |             | available | 20            | 20           |
| 157e862c-7604-5d1b-b80a-37559a88e65d | opensds-files-default   |             | available | 20            | 20           |
+--------------------------------------+-------------------------+-------------+-----------+---------------+--------------+
root@node01:~/gopath/src/github.com/opensds/opensds (development) #
```
