### PR TITLE
Fix content-type for keystone receiver

### DIFF
--- a/client/receiver.go
+++ b/client/receiver.go
@@ -220,6 +220,7 @@ func (k *KeystoneReceiver) Recv(url string, method string, body interface{}, out
 		}
 
 		headers := HeaderOption{}
+		headers["Content-Type"] = constants.ContentType
 		headers[constants.AuthTokenHeader] = k.Auth.TokenID
 		return request(url, method, headers, body, output)
 	})


### PR DESCRIPTION
This fix content-type issue in v0.6.2-Daito-RC1 tag
