### PR TITLE
Fix for fileshare mount issue

### DIFF
--- a/contrib/drivers/filesharedrivers/nfs/cli.go
+++ b/contrib/drivers/filesharedrivers/nfs/cli.go
@@ -77,8 +77,8 @@ func (c *Cli) CreateAccess(accessto, accesscapability, fname string) error {
 
 func (c *Cli) DeleteAccess(accessto, fname string) error {
 	var accesstoAndMount string
-	sharePath := path.Join("mnt/", fname)
-	accesstoAndMount = fmt.Sprintf("%s:/%s", accessto, strings.Replace(sharePath, "-", "_", -1))
+	sharePath := path.Join(MountPath, fname)
+	accesstoAndMount = fmt.Sprintf("%s:%s", accessto, strings.Replace(sharePath, "-", "_", -1))
 	cmd := []string{
 		"env", "LC_ALL=C",
 		"exportfs",

--- a/contrib/drivers/filesharedrivers/nfs/cli.go
+++ b/contrib/drivers/filesharedrivers/nfs/cli.go
@@ -54,14 +54,14 @@ func (c *Cli) GetExportLocation(share_name, ip string) string {
 		return ""
 	}
 	var exportLocation string
-	sharePath := path.Join("var/", share_name)
+	sharePath := path.Join("mnt/", share_name)
 	exportLocation = fmt.Sprintf("%s:/%s", server, strings.Replace(sharePath, "-", "_", -1))
 	return exportLocation
 }
 
 func (c *Cli) CreateAccess(accessto, accesscapability, fname string) error {
 	var accesstoAndMount string
-	sharePath := path.Join("var/", fname)
+	sharePath := path.Join("mnt/", fname)
 	accesstoAndMount = fmt.Sprintf("%s:/%s", accessto, strings.Replace(sharePath, "-", "_", -1))
 	cmd := []string{
 		"env", "LC_ALL=C",
@@ -77,7 +77,7 @@ func (c *Cli) CreateAccess(accessto, accesscapability, fname string) error {
 
 func (c *Cli) DeleteAccess(accessto, fname string) error {
 	var accesstoAndMount string
-	sharePath := path.Join("var/", fname)
+	sharePath := path.Join("mnt/", fname)
 	accesstoAndMount = fmt.Sprintf("%s:/%s", accessto, strings.Replace(sharePath, "-", "_", -1))
 	cmd := []string{
 		"env", "LC_ALL=C",

--- a/contrib/drivers/filesharedrivers/nfs/cli.go
+++ b/contrib/drivers/filesharedrivers/nfs/cli.go
@@ -54,15 +54,15 @@ func (c *Cli) GetExportLocation(share_name, ip string) string {
 		return ""
 	}
 	var exportLocation string
-	sharePath := path.Join("mnt/", share_name)
-	exportLocation = fmt.Sprintf("%s:/%s", server, strings.Replace(sharePath, "-", "_", -1))
+	sharePath := path.Join(MountPath, share_name)
+	exportLocation = fmt.Sprintf("%s:%s", server, strings.Replace(sharePath, "-", "_", -1))
 	return exportLocation
 }
 
 func (c *Cli) CreateAccess(accessto, accesscapability, fname string) error {
 	var accesstoAndMount string
-	sharePath := path.Join("mnt/", fname)
-	accesstoAndMount = fmt.Sprintf("%s:/%s", accessto, strings.Replace(sharePath, "-", "_", -1))
+	sharePath := path.Join(MountPath, fname)
+	accesstoAndMount = fmt.Sprintf("%s:%s", accessto, strings.Replace(sharePath, "-", "_", -1))
 	cmd := []string{
 		"env", "LC_ALL=C",
 		"exportfs",

--- a/contrib/drivers/filesharedrivers/nfs/nfs_test.go
+++ b/contrib/drivers/filesharedrivers/nfs/nfs_test.go
@@ -129,7 +129,7 @@ func TestCreateFileShare(t *testing.T) {
 		Description:     "fileshare for testing",
 		Size:            int64(1),
 		Protocols:       []string{"nfs"},
-		ExportLocations: []string{"11.242.178.20:/var/test001"},
+		ExportLocations: []string{"11.242.178.20:/mnt/test001"},
 		Metadata: map[string]string{
 			"lvPath":           "/dev/vg001/test001",
 			"nfsFileshareID":   "e1bb066c-5ce7-46eb-9336-25508cee9f71",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Corrected the returing export location. Previous it was, [IP:/var/<fs name>]

now it is: [IP:/mnt/<fs name>]

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
