### PR TITLE
Update GetVolume Filters and Add ESXI osType support for HOST API

### DIFF
--- a/openapi-spec/swagger.yaml
+++ b/openapi-spec/swagger.yaml
@@ -2831,6 +2831,7 @@ components:
           enum:
           - linux
           - windows
+          - esxi
         hostName:
           type: string
           minLength: 1

--- a/pkg/db/drivers/etcd/etcd.go
+++ b/pkg/db/drivers/etcd/etcd.go
@@ -1917,6 +1917,10 @@ func (c *Client) FindVolumeValue(k string, p *model.VolumeSpec) string {
 		return p.ProfileId
 	case "GroupId":
 		return p.GroupId
+	case "DurableName":
+		return p.Identifier.DurableName
+	case "DurableNameFormat":
+		return p.Identifier.DurableNameFormat
 	}
 	return ""
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
* Add Filters for DurableName for Volume Get API.
* Add suport for ESXI osType for Host create API swagger.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1083 

**What happened:**
NBP plugin (VMWARe NGC and VRO ) need to query volume by unique_identifier i.e. DurableName.

**What you expected to happen:**
GET /block/volumes?DurableName=<unique_id> should list Volumes based on this filter.