### PR TITLE
Add host parameter pattern into swagger

### DIFF
--- a/openapi-spec/swagger.yaml
+++ b/openapi-spec/swagger.yaml
@@ -2982,10 +2982,13 @@ components:
           type: string
           minLength: 1
           maxLength: 64
-          description: Only numbers, letters, '-', '_', '.' in ASCII characters are allowed.
+          pattern: "^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$"
+          description: Only numbers, letters, '-', '.' in ASCII characters are allowed.
+          example: opensds-node1
         ip:
           type: string
           description: IP address of the host, mandatory
+          pattern: "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$"
           example: 8.8.8.8
         port:
           maximum: 65535
@@ -3019,6 +3022,7 @@ components:
             maxLength: 64
             minLength: 1
             description: name or uuid of availablity zone
+          uniqueItems: true
         initiators:
           type: array
           description: Initiator of host
@@ -3049,10 +3053,13 @@ components:
           type: string
           minLength: 1
           maxLength: 64
-          description: Only numbers, letters, '-', '_', '.' in ASCII characters are allowed.
+          pattern: "^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$"
+          description: Only numbers, letters, '-', '.' in ASCII characters are allowed.
+          example: opensds-node1
         ip:
           type: string
           description: IP address of the host, mandatory
+          pattern: "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$"
           example: 8.8.8.8
         port:
           maximum: 65535
@@ -3086,6 +3093,7 @@ components:
             maxLength: 64
             minLength: 1
             description: name or uuid of availablity zone
+          uniqueItems: true
         initiators:
           type: array
           description: Initiator of host


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1039 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
release-note

1. hostname validation
```
request body:
{
  "accessMode": "agentless",
  "hostName": "opensds-node1_",
  "osType": "linux",
  "ip": "11.242.181.25",
  "availabilityZones": [
    "default", "az2"
  ],
  "initiators": [
    {
      "portName": "iqn.1993-08.org.debian:01:45a3eaf29788",
      "protocol": "iscsi"
    }

  ]
}

response:
{"code":400,"message":"Request body has an error: doesn't match the schema: Error at \"/hostName\":JSON string doesn't match the regular expression '^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$'"}
```

2. ip validation
```
request body:
{
  "accessMode": "agentless",
  "hostName": "opensds-node",
  "osType": "linux",
  "ip": "11.242.181.2555",
  "availabilityZones": [
    "default", "az2"
  ],
  "initiators": [
    {
      "portName": "iqn.1993-08.org.debian:01:45a3eaf29788",
      "protocol": "iscsi"
    }

  ]
}

response:
{"code":400,"message":"Request body has an error: doesn't match the schema: Error at \"/ip\":JSON string doesn't match the regular expression '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$'"}
```
