### PR TITLE
Remove unreasonable validation of fileshare description

### DIFF
--- a/pkg/api/util/db.go
+++ b/pkg/api/util/db.go
@@ -193,18 +193,6 @@ func CreateFileShareDBEntry(ctx *c.Context, in *model.FileShareSpec) (*model.Fil
 		log.Error(errMsg)
 		return nil, errors.New(errMsg)
 	}
-	// validate the description
-	reg, err = regexp.Compile("[^a-zA-Z0-9 ]+")
-	if err != nil {
-		errMsg := fmt.Sprintf("regex compilation for file share description validation failed")
-		log.Error(errMsg)
-		return nil, errors.New(errMsg)
-	}
-	if reg.MatchString(in.Description) {
-		errMsg := fmt.Sprintf("invalid fileshare description and it has some special characters")
-		log.Error(errMsg)
-		return nil, errors.New(errMsg)
-	}
 
 	in.UserId = ctx.UserId
 	in.Status = model.FileShareCreating

--- a/pkg/api/util/db_test.go
+++ b/pkg/api/util/db_test.go
@@ -528,17 +528,6 @@ func TestCreateFileShareDBEntry(t *testing.T) {
 		expectedError := "fileshare name length should not be more than 255 characters. input name length is : " + strconv.Itoa(len(in.Name))
 		assertTestResult(t, err.Error(), expectedError)
 	})
-
-	t.Run("Special characters in file share description are not allowed", func(t *testing.T) {
-		in.Size, in.Name, in.ProfileId, in.Description = int64(1), "sample-fileshare-01", "b3585ebe-c42c-120g-b28e-f373746a71ca", "#FileShare Code!$! test"
-		mockClient := new(dbtest.Client)
-		mockClient.On("CreateFileShare", context.NewAdminContext(), in).Return(&SampleFileShares[0], nil)
-		db.C = mockClient
-
-		_, err := CreateFileShareDBEntry(context.NewAdminContext(), in)
-		expectedError := "invalid fileshare description and it has some special characters"
-		assertTestResult(t, err.Error(), expectedError)
-	})
 }
 
 func TestDeleteFileShareDBEntry(t *testing.T) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

this pr will remove validation of file share description.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
