### PR TITLE
Volume Identifier for Oceanstor

### DIFF
--- a/contrib/drivers/huawei/oceanstor/oceanstor.go
+++ b/contrib/drivers/huawei/oceanstor/oceanstor.go
@@ -182,6 +182,7 @@ func (d *Driver) CreateVolume(opt *pb.CreateVolumeOpts) (*model.VolumeSpec, erro
 		Size:             Sector2Gb(lun.Capacity),
 		Description:      opt.GetDescription(),
 		AvailabilityZone: opt.GetAvailabilityZone(),
+		Identifier:  &model.Identifier{DurableName: lun.Wwn, DurableNameFormat: "NAA"},
 		Metadata: map[string]string{
 			KLunId: lun.Id,
 		},


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
As per design spec https://github.com/opensds/design-specs/pull/47 . We need to fetch volume identifier (wwn) from backend and fill  Identifer struct in opensds volumespec.
**Which issue this PR fixes** : 
fixes #997 

**Special notes for your reviewer**:
Ocenastore driver already fetching lun wwn , this change is to pick the wwn from the createVolume response  and fill identifier structure.
**Test Report** : 
Tested changes in opensds with Oceanstor backend , 