### PR TITLE
Add BaseModel to host to avoid null pointer

### DIFF
--- a/pkg/controller/dr/drcontroller.go
+++ b/pkg/controller/dr/drcontroller.go
@@ -297,6 +297,9 @@ func (p *PairOperator) doAttach(ctx *c.Context, vol *VolumeSpec, provisionerDock
 	var host *HostSpec
 	if len(hosts) == 0 {
 		host = &HostSpec{
+			BaseModel: &BaseModel{
+				Id: "",
+			},
 			HostName: attacherDock.NodeId,
 			IP:       attacherDock.Metadata["HostIp"],
 			OsType:   attacherDock.Metadata["OsType"],


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add a BaseModel for HostSpec with null Id to fix the null pointer in etcd.go

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1118 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
Relication can be created without setting hosts
```release-note
root@node01:~/gopath/src/github.com/opensds/opensds (development) # osdsctl host list
+----+----------+--------+----+------------+-------------------+
| Id | HostName | OsType | IP | AccessMode | AvailabilityZones |
+----+----------+--------+----+------------+-------------------+
+----+----------+--------+----+------------+-------------------+
root@node01:~/gopath/src/github.com/opensds/opensds (development) # osdsctl volume list
+--------------------------------------+----------------+-------------+------+------------------+-----------+--------------------------------------+
| Id                                   | Name           | Description | Size | AvailabilityZone | Status    | ProfileId                            |
+--------------------------------------+----------------+-------------+------+------------------+-----------+--------------------------------------+
| cb9674c8-c6f4-47ae-9eb0-30c1aa85ea5d | primary-vol1   |             | 1    | default          | available | ff128234-6c76-471f-a796-efe39c5551b8 |
| 9e498ea7-5ff5-4d78-acda-4ab99628c12b | secondary-vol1 |             | 1    | secondary        | available | ff128234-6c76-471f-a796-efe39c5551b8 |
+--------------------------------------+----------------+-------------+------+------------------+-----------+--------------------------------------+
root@node01:~/gopath/src/github.com/opensds/opensds (development) # osdsctl volume replication create cb9674c8-c6f4-47ae-9eb0-30c1aa85ea5d 9e498ea7-5ff5-4d78-acda-4ab99628c12b
+--------------------------------+--------------------------------------+
| Property                       | Value                                |
+--------------------------------+--------------------------------------+
| Id                             | 01fc3061-ce77-4312-9fb3-532cc6b481dc |
| CreatedAt                      | 2019-12-12T10:34:06                  |
| Name                           |                                      |
| Description                    |                                      |
| PrimaryVolumeId                | cb9674c8-c6f4-47ae-9eb0-30c1aa85ea5d |
| SecondaryVolumeId              | 9e498ea7-5ff5-4d78-acda-4ab99628c12b |
| AvailabilityZone               |                                      |
| PrimaryReplicationDriverData   | null                                 |
|                                |                                      |
| SecondaryReplicationDriverData | null                                 |
|                                |                                      |
| ReplicationStatus              | creating                             |
| ReplicationMode                | sync                                 |
| ReplicationPeriod              | 0                                    |
| ProfileId                      |                                      |
+--------------------------------+--------------------------------------+
root@node01:~/gopath/src/github.com/opensds/opensds (development) # osdsctl volume replication list
+--------------------------------------+------+-------------+--------------------------------------+--------------------------------------+-------------------+-----------------+
| Id                                   | Name | Description | PrimaryVolumeId                      | SecondaryVolumeId                    | ReplicationStatus | ReplicationMode |
+--------------------------------------+------+-------------+--------------------------------------+--------------------------------------+-------------------+-----------------+
| 01fc3061-ce77-4312-9fb3-532cc6b481dc |      |             | cb9674c8-c6f4-47ae-9eb0-30c1aa85ea5d | 9e498ea7-5ff5-4d78-acda-4ab99628c12b | available         | sync            |
+--------------------------------------+------+-------------+--------------------------------------+--------------------------------------+-------------------+-----------------+
```
