### PR TITLE
Add error prompt when creating volume failed

### DIFF
--- a/pkg/api/controllers/volume.go
+++ b/pkg/api/controllers/volume.go
@@ -69,6 +69,11 @@ func (v *VolumePortal) CreateVolume() {
 	if volume.ProfileId == "" {
 		log.Warning("Use default profile when user doesn't specify profile.")
 		prf, err = db.C.GetDefaultProfile(ctx)
+		if err != nil {
+			errMsg := fmt.Sprintf("get default profile failed: %s", err.Error())
+			v.ErrorHandle(model.ErrorBadRequest, errMsg)
+			return
+		}
 		// Assign the default profile id to volume so that users can know which
 		// profile is used for creating a volume.
 		volume.ProfileId = prf.Id


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add an error prompt when failed to get default profile during creating volume with default profile.

**Which issue this PR fixes** : fixes #1124 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
When creating volume with default profile failed, I can know what happened.
```release-note
root@node01:~/gopath/src/github.com/opensds/opensds (development) # osdsctl profile list
+--------------------------------------+---------+----------------+-------------+
| Id                                   | Name    | Description    | StorageType |
+--------------------------------------+---------+----------------+-------------+
| f832df81-883c-4149-a167-10c8e59fbc01 | default | default policy | block       |
+--------------------------------------+---------+----------------+-------------+
root@node01:~/gopath/src/github.com/opensds/opensds (development) # osdsctl volume create 1 --name=test-001
ERROR: get default profile failed: can't find profile(name: default_block, storageType:block)
root@node01:~/gopath/src/github.com/opensds/opensds (development) #
```
