### PR TITLE
Add the build and test script for ARM64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ build: prebuild osdsdock osdslet osdsapiserver osdsctl metricexporter
 prebuild:
 	mkdir -p $(BUILD_DIR)
 
-.PHONY: osdsdock osdslet osdsapiserver osdsctl docker test protoc goimports
+.PHONY: osdsdock osdslet osdsapiserver osdsctl docker docker.arm64 test protoc goimports
 
 osdsdock:
 	go build -ldflags '-w -s' -o $(BUILD_DIR)/bin/osdsdock github.com/opensds/opensds/cmd/osdsdock
@@ -55,6 +55,14 @@ docker: build
 	docker build cmd/osdsdock -t opensdsio/opensds-dock:latest
 	docker build cmd/osdslet -t opensdsio/opensds-controller:latest
 	docker build cmd/osdsapiserver -t opensdsio/opensds-apiserver:latest
+
+docker.arm64: build
+	cp $(BUILD_DIR)/bin/osdsdock ./cmd/osdsdock
+	cp $(BUILD_DIR)/bin/osdslet ./cmd/osdslet
+	cp $(BUILD_DIR)/bin/osdsapiserver ./cmd/osdsapiserver
+	docker build cmd/osdsdock -t opensdsio/opensds-dock-arm64:ci
+	docker build cmd/osdslet -t opensdsio/opensds-controller-arm64:ci
+	docker build cmd/osdsapiserver -t opensdsio/opensds-apiserver-arm64:ci
 
 test: build
 	install/CI/test

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,6 @@ require (
 	go.uber.org/zap v1.12.0 // indirect
 	golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
-	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/grpc v1.24.0
 	gopkg.in/ini.v1 v1.50.0 // indirect
 	gopkg.in/yaml.v2 v2.2.3

--- a/install/kubernetes/opensds-all-arm-dev.yaml
+++ b/install/kubernetes/opensds-all-arm-dev.yaml
@@ -1,0 +1,372 @@
+# Copyright 2019 The OpenSDS Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+##################################################################################################
+# Apiserver service
+##################################################################################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: apiserver
+  namespace: opensds
+  labels:
+    app: apiserver
+    service: apiserver
+spec:
+  ports:
+  - port: 50040
+    name: http-apiserver
+  selector:
+    app: apiserver
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: apiserver-v1beta
+  namespace: opensds
+  labels:
+    app: apiserver
+    version: v1beta
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: apiserver
+        version: v1beta
+    spec:
+      containers:
+      - name: apiserver
+        image: opensdsio/opensds-apiserver-arm64:ci
+        imagePullPolicy: IfNotPresent
+        command: ["bin/sh"]
+        args: ["-c", "/usr/bin/osdsapiserver -logtostderr"]
+        ports:
+        - containerPort: 50040
+        volumeMounts:
+        - name: opensds-conf-dir
+          mountPath: /etc/opensds
+      volumes:
+      - name: opensds-conf-dir
+        hostPath:
+          path: /etc/opensds
+          type: Directory
+---
+##################################################################################################
+# Controller service
+##################################################################################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: controller
+  namespace: opensds
+  labels:
+    app: controller
+    service: controller
+spec:
+  ports:
+  - port: 50049
+    name: tcp-controller
+  selector:
+    app: controller
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: controller-v1beta
+  namespace: opensds
+  labels:
+    app: controller
+    version: v1beta
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: controller
+        version: v1beta
+    spec:
+      containers:
+      - name: controller
+        image: opensdsio/opensds-controller-arm64:ci
+        imagePullPolicy: IfNotPresent
+        command: ["bin/sh"]
+        args: ["-c", "/usr/bin/osdslet -logtostderr"]
+        ports:
+        - containerPort: 50049
+        volumeMounts:
+        - name: opensds-conf-dir
+          mountPath: /etc/opensds
+      volumes:
+        - name: opensds-conf-dir
+          hostPath:
+            path: /etc/opensds
+            type: Directory
+---
+##################################################################################################
+# Dock service
+##################################################################################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: dock
+  namespace: opensds
+  labels:
+    app: dock
+    service: dock
+spec:
+  ports:
+  - port: 50050
+    name: tcp-dock
+  selector:
+    app: dock
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: dock-v1beta
+  namespace: opensds
+  labels:
+    app: dock
+    version: v1beta
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: dock
+        version: v1beta
+    spec:
+      containers:
+        - name: dock
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+          image: opensdsio/opensds-dock-arm64:ci
+          imagePullPolicy: IfNotPresent
+          command: ["bin/sh"]
+          args: ["-c", "/usr/sbin/tgtd; /usr/bin/osdsdock -logtostderr"]
+          ports:
+          - containerPort: 50050
+          volumeMounts:
+          - name: opensds-conf-dir
+            mountPath: /etc/opensds
+          - name: ceph-conf-dir
+            mountPath: /etc/ceph
+          - name: tgt-conf-dir
+            mountPath: /etc/tgt
+            mountPropagation: "Bidirectional"
+          - name: run-dir
+            mountPath: /run
+            mountPropagation: "Bidirectional"
+          - name: dev-dir
+            mountPath: /dev
+            mountPropagation: "HostToContainer"
+          - name: local-time-file
+            mountPath: /etc/localtime
+            readOnly: true
+          - name: lib-modules-dir
+            mountPath: /lib/modules
+            readOnly: true
+      volumes:
+        - name: opensds-conf-dir
+          hostPath:
+            path: /etc/opensds
+            type: Directory
+        - name: ceph-conf-dir
+          hostPath:
+            path: /etc/ceph
+            type: DirectoryOrCreate
+        - name: tgt-conf-dir
+          hostPath:
+            path: /etc/tgt
+            type: Directory
+        - name: run-dir
+          hostPath:
+            path: /run
+            type: Directory
+        - name: dev-dir
+          hostPath:
+            path: /dev
+            type: Directory
+        - name: local-time-file
+          hostPath:
+            path: /etc/localtime
+            type: File
+        - name: lib-modules-dir
+          hostPath:
+            path: /lib/modules
+            type: Directory
+---
+##################################################################################################
+# Dashboard service
+##################################################################################################
+# apiVersion: v1
+# kind: Service
+# metadata:
+  # name: dashboard
+  # namespace: opensds
+  # labels:
+    # app: dashboard
+    # service: dashboard
+# spec:
+  # ports:
+  # - port: 8088
+    # nodePort: 31975
+    # name: http-dashboard
+  # selector:
+    # app: dashboard
+  # type: NodePort
+# ---
+# apiVersion: extensions/v1beta1
+# kind: Deployment
+# metadata:
+  # name: dashboard-v1beta
+  # namespace: opensds
+  # labels:
+    # app: dashboard
+    # version: v1beta
+# spec:
+  # replicas: 1
+  # template:
+    # metadata:
+      # labels:
+        # app: dashboard
+        # version: v1beta
+    # spec:
+      # containers:
+      # - name: dashboard
+        # image: opensdsio/dashboard:latest
+        # env:
+        # - name: OPENSDS_AUTH_URL
+          # value: http://authchecker.opensds.svc.cluster.local/identity
+        # - name: OPENSDS_HOTPOT_URL
+          # value: http://apiserver.opensds.svc.cluster.local:50040
+        # - name: OPENSDS_GELATO_URL
+          # value: http://127.0.0.1:8089
+        # imagePullPolicy: IfNotPresent
+        # ports:
+        # - containerPort: 8088
+---
+##################################################################################################
+# DB service
+##################################################################################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: db
+  namespace: opensds
+  labels:
+    app: db
+    service: db
+spec:
+  ports:
+  - port: 2379
+    name: tcp-db1
+  - port: 2380
+    name: tcp-db2
+  selector:
+    app: db
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: db-v1
+  namespace: opensds
+  labels:
+    app: db
+    version: v1
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: db
+        version: v1
+    spec:
+      containers:
+      - name: db
+        image: opensdsio/etcd-arm64:v3.3.18
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: ETCD_UNSUPPORTED_ARCH
+          value: "arm64"
+        command: ["/bin/sh"]
+        args: ["-c", "/usr/local/bin/etcd \
+          --name s1 \
+          --listen-client-urls http://0.0.0.0:2379 \
+          --advertise-client-urls http://0.0.0.0:2379 \
+          --listen-peer-urls http://0.0.0.0:2380 \
+          --initial-advertise-peer-urls http://0.0.0.0:2380 \
+          --initial-cluster s1=http://0.0.0.0:2380"]
+        ports:
+        - containerPort: 2379
+        - containerPort: 2380
+        volumeMounts:
+        - name: etcd-cert-dir
+          mountPath: /etc/ssl/certs
+      volumes:
+      - name: etcd-cert-dir
+        hostPath:
+          path: /usr/share/ca-certificates/
+          type: Directory
+---
+##################################################################################################
+# Authchecker service
+##################################################################################################
+# apiVersion: v1
+# kind: Service
+# metadata:
+  # name: authchecker
+  # namespace: opensds
+  # labels:
+    # app: authchecker
+    # service: authchecker
+# spec:
+  # ports:
+  # - port: 80
+    # name: http-authchecker
+  # selector:
+    # app: authchecker
+# ---
+# apiVersion: extensions/v1beta1
+# kind: Deployment
+# metadata:
+  # name: authchecker-v1
+  # namespace: opensds
+  # labels:
+    # app: authchecker
+    # version: v1
+# spec:
+  # replicas: 1
+  # template:
+    # metadata:
+      # labels:
+        # app: authchecker
+        # version: v1
+    # spec:
+      # containers:
+      # - name: authchecker
+        # securityContext:
+          # privileged: true
+          # capabilities:
+            # add: ["SYS_ADMIN"]
+          # allowPrivilegeEscalation: true
+        # image: opensdsio/opensds-authchecker:latest
+        # imagePullPolicy: IfNotPresent
+        # ports:
+        # - containerPort: 80
+---


### PR DESCRIPTION
- Add docker.arm64 in Makefile, use make docker.arm64 to build images
  for arm.
- Add opensds-all-arm-dev.yaml to test opensds with noauth

Signed-off-by: wangzihao <wangzihao18@huawei.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR add the support for building opensds on ARM64. There are some ARM servers like huawei cloud is used to storage. Opensds may need to run on ARM.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
fixes #1130 
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
NONE