### PR TITLE
Fix the issue of vstore account of OceanStor

### DIFF
--- a/contrib/drivers/huawei/oceanstor/common.go
+++ b/contrib/drivers/huawei/oceanstor/common.go
@@ -14,6 +14,7 @@ import (
 type AuthOptions struct {
 	Username        string `yaml:"username,omitempty"`
 	Password        string `yaml:"password,omitempty"`
+	VstoreName      string `yaml:"vstoreName,omitempty"`
 	PwdEncrypter    string `yaml:"PwdEncrypter,omitempty"`
 	EnableEncrypted bool   `yaml:"EnableEncrypted,omitempty"`
 	Endpoints       string `yaml:"endpoints,omitempty"`

--- a/contrib/drivers/huawei/oceanstor/constants.go
+++ b/contrib/drivers/huawei/oceanstor/constants.go
@@ -53,10 +53,11 @@ const (
 
 // Error Code
 const (
-	ErrorConnectToServer      = -403
-	ErrorUnauthorizedToServer = -401
-	ErrorObjectUnavailable    = 1077948996
-	ErrorHostGroupNotExist    = 1077937500
+	ErrorConnectToServer        = -403
+	ErrorUnauthorizedToServer   = -401
+	ErrorObjectUnavailable      = 1077948996
+	ErrorHostGroupNotExist      = 1077937500
+	ErrorObjectNameAlreadyExist = 1077948993
 )
 
 // misc

--- a/contrib/drivers/huawei/oceanstor/oceanstor.go
+++ b/contrib/drivers/huawei/oceanstor/oceanstor.go
@@ -541,8 +541,8 @@ func (d *Driver) InitializeConnectionFC(opt *pb.CreateVolumeAttachmentOpts) (*mo
 	}
 
 	// Not use FC switch
-	initiatorName := GetInitiatorName(opt.GetHostInfo().GetInitiators(), opt.GetAccessProtocol())
-	tgtPortWWNs, initTargMap, err := d.connectFCUseNoSwitch(opt, initiatorName, hostId)
+	initiators := GetInitiatorsByProtocol(opt.GetHostInfo().GetInitiators(), opt.GetAccessProtocol())
+	tgtPortWWNs, initTargMap, err := d.connectFCUseNoSwitch(opt, initiators, hostId)
 	if err != nil {
 		return nil, err
 	}
@@ -575,8 +575,8 @@ func (d *Driver) InitializeConnectionFC(opt *pb.CreateVolumeAttachmentOpts) (*mo
 	return fcInfo, nil
 }
 
-func (d *Driver) connectFCUseNoSwitch(opt *pb.CreateVolumeAttachmentOpts, wwpns string, hostId string) ([]string, map[string][]string, error) {
-	wwns := strings.Split(wwpns, ",")
+func (d *Driver) connectFCUseNoSwitch(opt *pb.CreateVolumeAttachmentOpts, initiators []string, hostId string) ([]string, map[string][]string, error) {
+	wwns := initiators
 
 	onlineWWNsInHost, err := d.client.GetHostOnlineFCInitiators(hostId)
 	if err != nil {

--- a/contrib/drivers/utils/utils.go
+++ b/contrib/drivers/utils/utils.go
@@ -27,3 +27,15 @@ func GetInitiatorName(initiators []*pb.Initiator, protocol string) string {
 	}
 	return ""
 }
+
+func GetInitiatorsByProtocol(initiators []*pb.Initiator, protocol string) []string {
+	var protocolInitiators []string
+
+	for _, initiator := range initiators {
+		if initiator.Protocol == protocol {
+			protocolInitiators = append(protocolInitiators, initiator.PortName)
+		}
+	}
+
+	return protocolInitiators
+}

--- a/examples/driver/huawei_oceanstor_block.yaml
+++ b/examples/driver/huawei_oceanstor_block.yaml
@@ -1,6 +1,7 @@
 authOptions:
   username: "root"
   password: "Admin@123"
+  vstoreName: ""
   # Whether to encrypt the password. If enabled, the value of the password must be ciphertext.
   EnableEncrypted: false
   # Encryption and decryption tool. Default value is aes. The decryption tool can only decrypt the corresponding ciphertext.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The OceanStor driver doesn't support vStore account When tested OceanStor driver. This pr will add vStor lable in driver configure file to fix this issue.

**Release note**:

It's tested under OceanStore 18500 V5 environment.  The code will not affect current feature.

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
