### PR TITLE
Post Release:Fix for beego framework issue #1169

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/LINBIT/godrbdutils v0.0.0-20180425110027-65b98a0f103a
 	github.com/RoaringBitmap/roaring v0.4.21 // indirect
 	github.com/appleboy/easyssh-proxy v1.2.0
-	github.com/astaxie/beego v1.11.1
+	github.com/astaxie/beego v1.12.0
 	github.com/beorn7/perks v1.0.0 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/ceph/go-ceph v0.0.0-20170728144007-81e4191e131b


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
There is failure in CI. 
fatal: Authentication failed for 'https://github.com/belogik/goes/'
The reason is: beego usses '/belogik/goes/' repo internally in verion v1.11.1, now that repo has been deleted so our build is failing. (#1169 )

In latest beego V1.12.0, this issue is handled and merged. Below is the link:
https://github.com/astaxie/beego/pull/3468/files

So we need updated version of beego, i.e V1.12.0

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
