### PR TITLE
Multiple Initiators support from connector side

### DIFF
--- a/contrib/connector/connector.go
+++ b/contrib/connector/connector.go
@@ -42,7 +42,7 @@ const (
 type Connector interface {
 	Attach(map[string]interface{}) (string, error)
 	Detach(map[string]interface{}) error
-	GetInitiatorInfo() (string, error)
+	GetInitiatorInfo() ([]string, error)
 }
 
 var cnts = map[string]Connector{}

--- a/contrib/connector/fc/fc.go
+++ b/contrib/connector/fc/fc.go
@@ -41,6 +41,6 @@ func (f *FC) Detach(conn map[string]interface{}) error {
 }
 
 // GetInitiatorInfo ...
-func (f *FC) GetInitiatorInfo() (string, error) {
+func (f *FC) GetInitiatorInfo() ([]string, error) {
 	return getInitiatorInfo()
 }

--- a/contrib/connector/fc/fibreChannel.go
+++ b/contrib/connector/fc/fibreChannel.go
@@ -227,22 +227,23 @@ func getFChbasInfo() ([]map[string]string, error) {
 	return hbasInfos, nil
 }
 
-func getInitiatorInfo() (string, error) {
+func getInitiatorInfo() ([]string, error) {
 	hbas, err := getFChbasInfo()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	var initiatorInfo []string
-
 	for _, hba := range hbas {
 		if v, ok := hba[connector.PortName]; ok {
-			initiatorInfo = append(initiatorInfo, "port_name:"+v)
-		}
-		if v, ok := hba[connector.NodeName]; ok {
-			initiatorInfo = append(initiatorInfo, "node_name:"+v)
+			initiatorInfo = append(initiatorInfo, v)
 		}
 	}
 
-	return strings.Join(initiatorInfo, ","), nil
+	//Check for atleast one initiator
+	if (0 == len(initiatorInfo)){
+		return nil, errors.New("No initiator info found.")
+	}
+
+	return initiatorInfo, nil
 }

--- a/contrib/connector/iscsi/helper.go
+++ b/contrib/connector/iscsi/helper.go
@@ -372,19 +372,19 @@ func getTgtPortalAndTgtIQN() (string, string, error) {
 
 }
 
-func getInitiatorInfo() (string, error) {
+func getInitiatorInfo() ([]string, error) {
 	initiators, err := getInitiator()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	if len(initiators) == 0 {
-		return "", errors.New("No iqn found")
+		return nil, errors.New("No iqn found")
 	}
 
 	if len(initiators) > 1 {
-		return "", errors.New("the number of iqn is wrong")
+		return nil, errors.New("the number of iqn is wrong")
 	}
 
-	return initiators[0], nil
+	return initiators, nil
 }

--- a/contrib/connector/iscsi/iscsi.go
+++ b/contrib/connector/iscsi/iscsi.go
@@ -33,6 +33,6 @@ func (isc *Iscsi) Detach(conn map[string]interface{}) error {
 }
 
 // GetInitiatorInfo implementation
-func (isc *Iscsi) GetInitiatorInfo() (string, error) {
+func (isc *Iscsi) GetInitiatorInfo() ([]string, error) {
 	return getInitiatorInfo()
 }

--- a/contrib/connector/nfs/helper.go
+++ b/contrib/connector/nfs/helper.go
@@ -103,6 +103,6 @@ func disconnect(conn map[string]interface{}) error {
 	return errors.New("disconnect method of nfs is not implemented")
 }
 
-func getInitiatorInfo() (string, error) {
-	return "", errors.New("get initiator information method of nfs is not implemented")
+func getInitiatorInfo() ([]string, error) {
+	return nil, errors.New("get initiator information method of nfs is not implemented")
 }

--- a/contrib/connector/nfs/nfs.go
+++ b/contrib/connector/nfs/nfs.go
@@ -33,6 +33,6 @@ func (n *NFS) Detach(conn map[string]interface{}) error {
 }
 
 // GetInitiatorInfo implementation
-func (n *NFS) GetInitiatorInfo() (string, error) {
+func (n *NFS) GetInitiatorInfo() ([]string, error) {
 	return getInitiatorInfo()
 }

--- a/contrib/connector/nvmeof/nvmeof.go
+++ b/contrib/connector/nvmeof/nvmeof.go
@@ -35,6 +35,6 @@ func (nof *Nvmeof) Detach(conn map[string]interface{}) error {
 }
 
 // GetInitiatorInfo implementation
-func (nof *Nvmeof) GetInitiatorInfo() (string, error) {
+func (nof *Nvmeof) GetInitiatorInfo() ([]string, error) {
 	return getInitiatorInfo()
 }

--- a/contrib/connector/nvmeof/nvmeof_helper.go
+++ b/contrib/connector/nvmeof/nvmeof_helper.go
@@ -63,28 +63,32 @@ func GetInitiator() ([]string, error) {
 	return nqns, errors.New("can not find any nqn initiator")
 }
 
-func getInitiatorInfo() (string, error) {
+func getInitiatorInfo() ([]string, error) {
 
 	initiators, err := GetInitiator()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	if len(initiators) == 0 {
-		return "", errors.New("no nqn found")
+		return nil, errors.New("no nqn found")
 	}
 
 	if len(initiators) > 1 {
-		return "", errors.New("the number of nqn is wrong")
+		return nil, errors.New("the number of nqn is wrong")
 	}
 
 	hostName, err := connector.GetHostName()
 	if err != nil {
-		return "", errors.New("can not get hostname")
+		return nil, errors.New("can not get hostname")
 	}
 
-	info := initiators[0] + "." + hostName
-	return info, nil
+	hostName = initiators[0] + "." + hostName
+
+	initiator := make([]string, 1)
+	initiator = append(initiator, hostName)
+
+	return initiator, nil
 }
 
 // GetNvmeDevice get all the nvme devices

--- a/contrib/connector/rbd/rbd.go
+++ b/contrib/connector/rbd/rbd.go
@@ -105,14 +105,18 @@ func (*RBD) Detach(conn map[string]interface{}) error {
 }
 
 // GetInitiatorInfo implementation
-func (*RBD) GetInitiatorInfo() (string, error) {
+func (*RBD) GetInitiatorInfo() ([]string, error) {
+
 	hostName, err := connector.GetHostName()
 
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return hostName, nil
+	initiator := make([]string, 1)
+	initiator = append(initiator, hostName)
+
+	return initiator, nil
 }
 
 func parseName(name string) (poolName, imageName, snapName string, err error) {

--- a/pkg/dock/discovery/discovery.go
+++ b/pkg/dock/discovery/discovery.go
@@ -265,7 +265,7 @@ func (add *attachDockDiscoverer) Discover() error {
 	}
 
 	var wwpns []string
-	for _, v := range strings.Split(fcInitiator, ",") {
+	for _, v := range fcInitiator {
 		if strings.Contains(v, "node_name") {
 			wwpns = append(wwpns, strings.Split(v, ":")[1])
 		}
@@ -284,7 +284,7 @@ func (add *attachDockDiscoverer) Discover() error {
 			"Platform":  runtime.GOARCH,
 			"OsType":    runtime.GOOS,
 			"HostIp":    bindIp,
-			"Initiator": localIqn,
+			"Initiator": localIqn[0],
 			"WWPNS":     strings.Join(wwpns, ","),
 		},
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Initiator info can be more than one set, Current connector code supports only one set of initiator to be returned. So getInitiatorInfo() need to support returning multiple initiator info

All the connectors which implement this interface will have to change to support list of initiators

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
This PR addresses the hotpot side fixes for the issue https://github.com/opensds/nbp/issues/323

**Special notes for your reviewer**:
> Any other PR(s) this PR is dependant on: None

Testcases to execute:
Verify the initiator info in the host for different connectors

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
