### PR TITLE
Handle volume in batch

### DIFF
--- a/pkg/api/controllers/attachment.go
+++ b/pkg/api/controllers/attachment.go
@@ -144,7 +144,6 @@ func (v *VolumeAttachmentPortal) CreateVolumeAttachment() {
 		log.Error("when connecting controller client:", err)
 		return
 	}
-	defer v.CtrClient.Close()
 
 	// // Note: In some protocols, there is no related initiator
 	// var initiatorPort = ""
@@ -328,7 +327,6 @@ func (v *VolumeAttachmentPortal) DeleteVolumeAttachment() {
 		log.Error("when connecting controller client:", err)
 		return
 	}
-	defer v.CtrClient.Close()
 
 	var initiators []*pb.Initiator
 	for _, e := range host.Initiators {

--- a/pkg/api/controllers/fileshare.go
+++ b/pkg/api/controllers/fileshare.go
@@ -104,7 +104,6 @@ func (f *FileSharePortal) CreateFileShareAcl() {
 		log.Error("when connecting controller client:", err)
 		return
 	}
-	defer f.CtrClient.Close()
 
 	opt := &pb.CreateFileShareAclOpts{
 		Id:               result.Id,
@@ -249,7 +248,6 @@ func (f *FileSharePortal) CreateFileShare() {
 		log.Error("when connecting controller client:", err)
 		return
 	}
-	defer f.CtrClient.Close()
 
 	opt := &pb.CreateFileShareOpts{
 		Id:               result.Id,
@@ -429,7 +427,6 @@ func (f *FileSharePortal) DeleteFileShareAcl() {
 		log.Error("when connecting controller client:", err)
 		return
 	}
-	defer f.CtrClient.Close()
 
 	opt := &pb.DeleteFileShareAclOpts{
 		Id:               acl.Id,
@@ -507,7 +504,6 @@ func (f *FileSharePortal) DeleteFileShare() {
 		log.Error("when connecting controller client:", err)
 		return
 	}
-	defer f.CtrClient.Close()
 
 	opt := &pb.DeleteFileShareOpts{
 		Id:              fileshare.Id,
@@ -603,7 +599,6 @@ func (f *FileShareSnapshotPortal) CreateFileShareSnapshot() {
 		log.Error("when connecting controller client:", err)
 		return
 	}
-	defer f.CtrClient.Close()
 
 	opt := &pb.CreateFileShareSnapshotOpts{
 		Id:          result.Id,
@@ -742,7 +737,6 @@ func (f *FileShareSnapshotPortal) DeleteFileShareSnapshot() {
 		log.Error("when connecting controller client:", err)
 		return
 	}
-	defer f.CtrClient.Close()
 
 	opt := &pb.DeleteFileShareSnapshotOpts{
 		Id:          snapshot.Id,

--- a/pkg/api/controllers/metrics.go
+++ b/pkg/api/controllers/metrics.go
@@ -104,7 +104,6 @@ func (m *MetricsPortal) GetMetrics() {
 		log.Error("when connecting controller client:", err)
 		return
 	}
-	defer m.CtrClient.Close()
 
 	opt := &pb.GetMetricsOpts{
 		InstanceId: getMetricSpec.InstanceId,
@@ -264,7 +263,6 @@ func (m *MetricsPortal) CollectMetrics() {
 		log.Errorf("error when connecting controller client: %s", err.Error())
 		return
 	}
-	defer m.CtrClient.Close()
 
 	opt := &pb.CollectMetricsOpts{
 		DriverName: collMetricSpec.DriverType,
@@ -293,7 +291,6 @@ func (m *MetricsPortal) GetUrls() {
 		log.Error("when connecting controller client:", err)
 		return
 	}
-	defer m.CtrClient.Close()
 
 	opt := &pb.NoParams{}
 	res, err := m.CtrClient.GetUrls(context.Background(), opt)

--- a/pkg/api/controllers/replication.go
+++ b/pkg/api/controllers/replication.go
@@ -86,7 +86,6 @@ func (r *ReplicationPortal) CreateReplication() {
 		log.Error("when connecting controller client:", err)
 		return
 	}
-	defer r.CtrClient.Close()
 
 	opt := &pb.CreateReplicationOpts{
 		Id:                result.Id,
@@ -273,7 +272,6 @@ func (r *ReplicationPortal) DeleteReplication() {
 		log.Error("when connecting controller client:", err)
 		return
 	}
-	defer r.CtrClient.Close()
 
 	opt := &pb.DeleteReplicationOpts{
 		Id:                rep.Id,
@@ -326,7 +324,6 @@ func (r *ReplicationPortal) EnableReplication() {
 		log.Error("when connecting controller client:", err)
 		return
 	}
-	defer r.CtrClient.Close()
 
 	opt := &pb.EnableReplicationOpts{
 		Id:                rep.Id,
@@ -379,7 +376,6 @@ func (r *ReplicationPortal) DisableReplication() {
 		log.Error("when connecting controller client:", err)
 		return
 	}
-	defer r.CtrClient.Close()
 
 	opt := &pb.DisableReplicationOpts{
 		Id:                rep.Id,
@@ -439,7 +435,6 @@ func (r *ReplicationPortal) FailoverReplication() {
 		log.Error("when connecting controller client:", err)
 		return
 	}
-	defer r.CtrClient.Close()
 
 	opt := &pb.FailoverReplicationOpts{
 		Id:                  rep.Id,

--- a/pkg/api/controllers/volume.go
+++ b/pkg/api/controllers/volume.go
@@ -109,7 +109,6 @@ func (v *VolumePortal) CreateVolume() {
 		log.Error("when connecting controller client:", err)
 		return
 	}
-	defer v.CtrClient.Close()
 
 	opt := &pb.CreateVolumeOpts{
 		Id:               result.Id,
@@ -266,7 +265,6 @@ func (v *VolumePortal) ExtendVolume() {
 		log.Error("when connecting controller client:", err)
 		return
 	}
-	defer v.CtrClient.Close()
 
 	opt := &pb.ExtendVolumeOpts{
 		Id:       id,
@@ -342,7 +340,6 @@ func (v *VolumePortal) DeleteVolume() {
 		log.Error("when connecting controller client:", err)
 		return
 	}
-	defer v.CtrClient.Close()
 
 	opt := &pb.DeleteVolumeOpts{
 		Id:        volume.Id,
@@ -431,7 +428,6 @@ func (v *VolumeSnapshotPortal) CreateVolumeSnapshot() {
 		log.Error("when connecting controller client:", err)
 		return
 	}
-	defer v.CtrClient.Close()
 
 	opt := &pb.CreateVolumeSnapshotOpts{
 		Id:          result.Id,
@@ -572,7 +568,6 @@ func (v *VolumeSnapshotPortal) DeleteVolumeSnapshot() {
 		log.Error("when connecting controller client:", err)
 		return
 	}
-	defer v.CtrClient.Close()
 
 	opt := &pb.DeleteVolumeSnapshotOpts{
 		Id:       snapshot.Id,

--- a/pkg/api/controllers/volumeGroup.go
+++ b/pkg/api/controllers/volumeGroup.go
@@ -85,7 +85,6 @@ func (v *VolumeGroupPortal) CreateVolumeGroup() {
 		log.Error("when connecting controller client:", err)
 		return
 	}
-	defer v.CtrClient.Close()
 
 	opt := &pb.CreateVolumeGroupOpts{
 		Id:               result.Id,
@@ -167,7 +166,6 @@ func (v *VolumeGroupPortal) UpdateVolumeGroup() {
 		log.Error("when connecting controller client:", err)
 		return
 	}
-	defer v.CtrClient.Close()
 
 	opt := &pb.UpdateVolumeGroupOpts{
 		Id:            id,
@@ -219,7 +217,6 @@ func (v *VolumeGroupPortal) DeleteVolumeGroup() {
 		log.Error("when connecting controller client:", err)
 		return
 	}
-	defer v.CtrClient.Close()
 
 	opt := &pb.DeleteVolumeGroupOpts{
 		Id:      id,

--- a/pkg/controller/client/client.go
+++ b/pkg/controller/client/client.go
@@ -15,10 +15,14 @@
 package client
 
 import (
+	"time"
+
 	log "github.com/golang/glog"
 	pb "github.com/opensds/opensds/pkg/model/proto"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/keepalive"
 )
 
 // Client interface provides an abstract description about how to interact
@@ -30,8 +34,6 @@ type Client interface {
 	pb.FileShareControllerClient
 
 	Connect(edp string) error
-
-	Close()
 }
 
 // client structure is one implementation of Client interface and will be
@@ -47,7 +49,15 @@ func NewClient() Client { return &client{} }
 
 func (c *client) Connect(edp string) error {
 	// Set up a connection to the Dock server.
-	conn, err := grpc.Dial(edp, grpc.WithInsecure())
+	if c.ClientConn != nil && c.ClientConn.GetState() == connectivity.Ready {
+		return nil
+	}
+	var kacp = keepalive.ClientParameters{
+		Time:                10 * time.Second, // send pings every 10 seconds if there is no activity
+		Timeout:             time.Second,      // wait 1 second for ping ack before considering the connection dead
+		PermitWithoutStream: true,             // send pings even without active streams
+	}
+	conn, err := grpc.Dial(edp, grpc.WithInsecure(), grpc.WithKeepaliveParams(kacp))
 	if err != nil {
 		log.Errorf("did not connect: %+v\n", err)
 		return err
@@ -58,8 +68,4 @@ func (c *client) Connect(edp string) error {
 	c.ClientConn = conn
 
 	return nil
-}
-
-func (c *client) Close() {
-	c.ClientConn.Close()
 }

--- a/pkg/controller/fileshare/filesharecontroller.go
+++ b/pkg/controller/fileshare/filesharecontroller.go
@@ -71,7 +71,6 @@ func (c *controller) CreateFileShareAcl(opt *pb.CreateFileShareAclOpts) (*model.
 		log.Error("create file share acl failed in file share controller:", err)
 		return nil, err
 	}
-	defer c.Client.Close()
 
 	if errorMsg := response.GetError(); errorMsg != nil {
 		return nil,
@@ -100,7 +99,6 @@ func (c *controller) DeleteFileShareAcl(opt *pb.DeleteFileShareAclOpts) error {
 		log.Error("delete file share acl failed in file share controller:", err)
 		return err
 	}
-	defer c.Client.Close()
 
 	if errorMsg := response.GetError(); errorMsg != nil {
 		return fmt.Errorf("failed to delete file share acl in file share controller, code: %v, message: %v",
@@ -123,7 +121,6 @@ func (c *controller) CreateFileShare(opt *pb.CreateFileShareOpts) (*model.FileSh
 		log.Error("create file share failed in file share controller:", err)
 		return nil, err
 	}
-	defer c.Client.Close()
 
 	log.V(5).Infof("dock create fleshare:  Sent to driver : %+v", c.DockInfo.DriverName)
 
@@ -154,7 +151,6 @@ func (c *controller) DeleteFileShare(opt *pb.DeleteFileShareOpts) error {
 		log.Error("delete file share failed in file share controller:", err)
 		return err
 	}
-	defer c.Client.Close()
 
 	if errorMsg := response.GetError(); errorMsg != nil {
 		return errors.New(errorMsg.GetDescription())
@@ -178,7 +174,6 @@ func (c *controller) CreateFileShareSnapshot(opt *pb.CreateFileShareSnapshotOpts
 		log.Error("create file share snapshot failed in file share controller:", err)
 		return nil, err
 	}
-	defer c.Client.Close()
 
 	if errorMsg := response.GetError(); errorMsg != nil {
 		return nil,
@@ -206,7 +201,6 @@ func (c *controller) DeleteFileShareSnapshot(opt *pb.DeleteFileShareSnapshotOpts
 		log.Error("delete file share snapshot failed in file share controller:", err)
 		return err
 	}
-	defer c.Client.Close()
 
 	if errorMsg := response.GetError(); errorMsg != nil {
 		return errors.New(errorMsg.GetDescription())

--- a/pkg/controller/metrics/metrics_controller.go
+++ b/pkg/controller/metrics/metrics_controller.go
@@ -290,7 +290,6 @@ func (c *controller) CollectMetrics(opt *pb.CollectMetricsOpts) ([]*model.Metric
 		log.Errorf("collect metrics failed in metrics controller: %s", err.Error())
 		return nil, err
 	}
-	defer c.Client.Close()
 
 	if errorMsg := response.GetError(); errorMsg != nil {
 		return nil,

--- a/pkg/controller/volume/volumecontroller.go
+++ b/pkg/controller/volume/volumecontroller.go
@@ -94,7 +94,6 @@ func (c *controller) CreateVolume(opt *pb.CreateVolumeOpts) (*model.VolumeSpec, 
 		log.Error("create volume failed in volume controller:", err)
 		return nil, err
 	}
-	defer c.Client.Close()
 
 	if errorMsg := response.GetError(); errorMsg != nil {
 		return nil,
@@ -123,7 +122,6 @@ func (c *controller) DeleteVolume(opt *pb.DeleteVolumeOpts) error {
 		log.Error("delete volume failed in volume controller:", err)
 		return err
 	}
-	defer c.Client.Close()
 
 	if errorMsg := response.GetError(); errorMsg != nil {
 		return errors.New(errorMsg.GetDescription())
@@ -143,7 +141,6 @@ func (c *controller) ExtendVolume(opt *pb.ExtendVolumeOpts) (*model.VolumeSpec, 
 		log.Error("extend volume failed in volume controller:", err)
 		return nil, err
 	}
-	defer c.Client.Close()
 
 	if errorMsg := response.GetError(); errorMsg != nil {
 		return nil,
@@ -171,7 +168,6 @@ func (c *controller) CreateVolumeAttachment(opt *pb.CreateVolumeAttachmentOpts) 
 		log.Error("create volume attachment failed in volume controller:", err)
 		return nil, err
 	}
-	defer c.Client.Close()
 
 	if errorMsg := response.GetError(); errorMsg != nil {
 		return nil,
@@ -201,7 +197,6 @@ func (c *controller) DeleteVolumeAttachment(opt *pb.DeleteVolumeAttachmentOpts) 
 		log.Error("delete volume attachment failed in volume controller:", err)
 		return err
 	}
-	defer c.Client.Close()
 
 	if errorMsg := response.GetError(); errorMsg != nil {
 		return errors.New(errorMsg.GetDescription())
@@ -221,7 +216,6 @@ func (c *controller) CreateVolumeSnapshot(opt *pb.CreateVolumeSnapshotOpts) (*mo
 		log.Error("create volume snapshot failed in volume controller:", err)
 		return nil, err
 	}
-	defer c.Client.Close()
 
 	if errorMsg := response.GetError(); errorMsg != nil {
 		return nil,
@@ -249,7 +243,6 @@ func (c *controller) DeleteVolumeSnapshot(opt *pb.DeleteVolumeSnapshotOpts) erro
 		log.Error("delete volume snapshot failed in volume controller:", err)
 		return err
 	}
-	defer c.Client.Close()
 
 	if errorMsg := response.GetError(); errorMsg != nil {
 		return errors.New(errorMsg.GetDescription())
@@ -269,7 +262,6 @@ func (c *controller) CreateReplication(opt *pb.CreateReplicationOpts) (*model.Re
 		log.Error("create volume replication failed in volume controller:", err)
 		return nil, err
 	}
-	defer c.Client.Close()
 
 	if errorMsg := response.GetError(); errorMsg != nil {
 		return nil,
@@ -297,7 +289,6 @@ func (c *controller) DeleteReplication(opt *pb.DeleteReplicationOpts) error {
 		log.Error("delete replication failed in volume controller:", err)
 		return err
 	}
-	defer c.Client.Close()
 
 	if errorMsg := response.GetError(); errorMsg != nil {
 		return errors.New(errorMsg.GetDescription())
@@ -317,7 +308,6 @@ func (c *controller) EnableReplication(opt *pb.EnableReplicationOpts) error {
 		log.Error("enable replication failed in volume controller:", err)
 		return err
 	}
-	defer c.Client.Close()
 
 	if errorMsg := response.GetError(); errorMsg != nil {
 		return errors.New(errorMsg.GetDescription())
@@ -337,7 +327,6 @@ func (c *controller) DisableReplication(opt *pb.DisableReplicationOpts) error {
 		log.Error("disable replication failed in volume controller:", err)
 		return err
 	}
-	defer c.Client.Close()
 
 	if errorMsg := response.GetError(); errorMsg != nil {
 		return errors.New(errorMsg.GetDescription())
@@ -357,7 +346,6 @@ func (c *controller) FailoverReplication(opt *pb.FailoverReplicationOpts) error 
 		log.Error("failover replication failed in volume controller:", err)
 		return err
 	}
-	defer c.Client.Close()
 
 	if errorMsg := response.GetError(); errorMsg != nil {
 		return errors.New(errorMsg.GetDescription())
@@ -377,7 +365,6 @@ func (c *controller) AttachVolume(opt *pb.AttachVolumeOpts) (string, error) {
 		log.Error("attach volume failed in volume controller:", err)
 		return "", err
 	}
-	defer c.Client.Close()
 
 	if errorMsg := response.GetError(); errorMsg != nil {
 		return "",
@@ -398,7 +385,6 @@ func (c *controller) DetachVolume(opt *pb.DetachVolumeOpts) error {
 		log.Error("detach volume failed in volume controller:", err)
 		return err
 	}
-	defer c.Client.Close()
 
 	if errorMsg := response.GetError(); errorMsg != nil {
 		return errors.New(errorMsg.GetDescription())
@@ -418,7 +404,6 @@ func (c *controller) CreateVolumeGroup(opt *pb.CreateVolumeGroupOpts) (*model.Vo
 		log.Error("create volume group failed in volume controller:", err)
 		return nil, err
 	}
-	defer c.Client.Close()
 
 	if errorMsg := response.GetError(); errorMsg != nil {
 		return nil,
@@ -446,7 +431,6 @@ func (c *controller) UpdateVolumeGroup(opt *pb.UpdateVolumeGroupOpts) (*model.Vo
 		log.Error("update volume group failed in volume controller:", err)
 		return nil, err
 	}
-	defer c.Client.Close()
 
 	if errorMsg := response.GetError(); errorMsg != nil {
 		return nil, fmt.Errorf("failed to update volume group in volume controller, code: %v, message: %v",
@@ -473,8 +457,6 @@ func (c *controller) DeleteVolumeGroup(opt *pb.DeleteVolumeGroupOpts) error {
 		log.Error("delete volume group failed in volume controller:", err)
 		return err
 	}
-
-	defer c.Client.Close()
 
 	if errorMsg := response.GetError(); errorMsg != nil {
 		return errors.New(errorMsg.GetDescription())

--- a/pkg/dock/client/client.go
+++ b/pkg/dock/client/client.go
@@ -15,9 +15,13 @@
 package client
 
 import (
+	"time"
+
 	log "github.com/golang/glog"
 	pb "github.com/opensds/opensds/pkg/model/proto"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/keepalive"
 )
 
 // Client interface provides an abstract description about how to interact
@@ -30,8 +34,6 @@ type Client interface {
 	pb.FileShareDockClient
 
 	Connect(edp string) error
-
-	Close()
 }
 
 // DockClient structure is one implementation of Client interface and will be
@@ -48,7 +50,15 @@ func NewClient() Client { return &DockClient{} }
 
 func (c *DockClient) Connect(edp string) error {
 	// Set up a connection to the Dock server.
-	conn, err := grpc.Dial(edp, grpc.WithInsecure())
+	if c.ClientConn != nil && c.ClientConn.GetState() == connectivity.Ready {
+		return nil
+	}
+	var kacp = keepalive.ClientParameters{
+		Time:                10 * time.Second, // send pings every 10 seconds if there is no activity
+		Timeout:             time.Second,      // wait 1 second for ping ack before considering the connection dead
+		PermitWithoutStream: true,             // send pings even without active streams
+	}
+	conn, err := grpc.Dial(edp, grpc.WithInsecure(), grpc.WithKeepaliveParams(kacp))
 	if err != nil {
 		log.Errorf("did not connect: %+v\n", err)
 		return err
@@ -60,8 +70,4 @@ func (c *DockClient) Connect(edp string) error {
 	c.ClientConn = conn
 
 	return nil
-}
-
-func (c *DockClient) Close() {
-	c.ClientConn.Close()
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Keep GRPC connection alive so we can create/delete/attach/detach volumes in a batch, otherwise GRPC connection would be closed unexpectedly.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1153 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
[root@master-node block]# kubectl create -f multi-pvc.yaml
storageclass.storage.k8s.io/csi-sc-opensdsplugin-block created
persistentvolumeclaim/csi-pvc-opensdsplugin-block1 created
persistentvolumeclaim/csi-pvc-opensdsplugin-block2 created
persistentvolumeclaim/csi-pvc-opensdsplugin-block3 created
persistentvolumeclaim/csi-pvc-opensdsplugin-block4 created
persistentvolumeclaim/csi-pvc-opensdsplugin-block5 created
persistentvolumeclaim/csi-pvc-opensdsplugin-block6 created
[root@master-node block]# kubectl get pvc
NAME                           STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                 AGE
csi-pvc-opensdsplugin-block1   Bound    pvc-442b20f3-3112-4b7a-9f72-24cf0306c744   1Gi        RWX            csi-sc-opensdsplugin-block   6s
csi-pvc-opensdsplugin-block2   Bound    pvc-7e5eff69-6694-4dba-b659-1f22adcbbf83   1Gi        RWX            csi-sc-opensdsplugin-block   6s
csi-pvc-opensdsplugin-block3   Bound    pvc-c6251101-94df-44ce-b755-b3ab6b635185   1Gi        RWX            csi-sc-opensdsplugin-block   6s
csi-pvc-opensdsplugin-block4   Bound    pvc-0029811b-a4cb-44af-ae8c-4f3bb81f760b   1Gi        RWX            csi-sc-opensdsplugin-block   6s
csi-pvc-opensdsplugin-block5   Bound    pvc-c1e37c41-0808-43db-a5c7-b9374602b29c   1Gi        RWX            csi-sc-opensdsplugin-block   6s
csi-pvc-opensdsplugin-block6   Bound    pvc-0263ef00-7a3c-4c1e-9fce-33c97f9b5738   1Gi        RWX            csi-sc-opensdsplugin-block   6s
[root@master-node opensds]# osdsctl volume list
+--------------------------------------+------------------------------------------+-------------+------+------------------+-----------+--------------------------------------+
| Id                                   | Name                                     | Description | Size | AvailabilityZone | Status    | ProfileId                            |
+--------------------------------------+------------------------------------------+-------------+------+------------------+-----------+--------------------------------------+
| dc8cd1bb-bff7-4fb2-911d-d50c77399129 | pvc-442b20f3-3112-4b7a-9f72-24cf0306c744 |             | 1    | default          | available | 85bf0d5b-f0ed-4573-ac1d-a21d61402bf9 |
| d6f4299b-19a4-46f9-b708-d5c6e641b4c0 | pvc-0263ef00-7a3c-4c1e-9fce-33c97f9b5738 |             | 1    | default          | available | 85bf0d5b-f0ed-4573-ac1d-a21d61402bf9 |
| 43ce6a63-7aa1-4b51-9de5-f793b90e07f0 | pvc-7e5eff69-6694-4dba-b659-1f22adcbbf83 |             | 1    | default          | available | 85bf0d5b-f0ed-4573-ac1d-a21d61402bf9 |
| 1c410bba-d0f3-4e9c-8c53-4730c4c8d17d | pvc-c1e37c41-0808-43db-a5c7-b9374602b29c |             | 1    | default          | available | 85bf0d5b-f0ed-4573-ac1d-a21d61402bf9 |
| 19b598b6-d7bf-48d9-b99b-a2f5f8b18334 | pvc-0029811b-a4cb-44af-ae8c-4f3bb81f760b |             | 1    | default          | available | 85bf0d5b-f0ed-4573-ac1d-a21d61402bf9 |
| 1279d516-9ac4-43bb-b014-348de3edb672 | pvc-c6251101-94df-44ce-b755-b3ab6b635185 |             | 1    | default          | available | 85bf0d5b-f0ed-4573-ac1d-a21d61402bf9 |
+--------------------------------------+------------------------------------------+-------------+------+------------------+-----------+--------------------------------------+
[root@master-node opensds]#
```
