### PR TITLE
Fix for Fileshare acl creation issue

### DIFF
--- a/osdsctl/cli/fileshareacl.go
+++ b/osdsctl/cli/fileshareacl.go
@@ -20,8 +20,6 @@ This module implements a entry into the OpenSDS service.
 package cli
 
 import (
-	"encoding/json"
-	"log"
 	"os"
 
 	"github.com/opensds/opensds/pkg/model"
@@ -37,6 +35,7 @@ var fileShareAclCommand = &cobra.Command{
 var fileShareAclCreateCommand = &cobra.Command{
 	Use:   "create <fileshare id>",
 	Short: "create a acl of specified fileshare in the cluster",
+	Example: "osdsctl fileshare acl create -a 10.0.0.10 -c \"Write\" -t ip 87be9ce5-6ecc-4ac3-8d6c-f5a58c9110e4",
 	Run:   fileShareAclCreateAction,
 }
 
@@ -60,7 +59,7 @@ var fileShareAclListCommand = &cobra.Command{
 
 var (
 	shareAclType             string
-	shareAclAccessCapability string
+	shareAclAccessCapability []string
 	shareAclAccessTo         string
 	shareAclDesp             string
 
@@ -73,9 +72,9 @@ func init() {
 	fileShareAclCommand.AddCommand(fileShareAclShowCommand)
 	fileShareAclCommand.AddCommand(fileShareAclListCommand)
 
-	fileShareAclCreateCommand.Flags().StringVarP(&shareAclType, "type", "t", "", "the type of access")
-	fileShareAclCreateCommand.Flags().StringVarP(&shareAclAccessCapability, "capability", "c", "", "the accessCapability for fileshare")
-	fileShareAclCreateCommand.Flags().StringVarP(&shareAclAccessTo, "accessTo", "a", "", "accessTo of the fileshare")
+	fileShareAclCreateCommand.Flags().StringVarP(&shareAclType, "type", "t", "", "the type of access. The Only current supported type is: ip")
+	fileShareAclCreateCommand.Flags().StringSliceVarP(&shareAclAccessCapability, "capability", "c", shareAclAccessCapability, "the accessCapability \"Read\" or \"Write\" for fileshare")
+	fileShareAclCreateCommand.Flags().StringVarP(&shareAclAccessTo, "accessTo", "a", "", "accessTo of the fileshare. A valid IPv4 format is supported")
 	fileShareAclCreateCommand.Flags().StringVarP(&shareAclDesp, "description", "d", "", "the description of of the fileshare acl")
 }
 
@@ -86,19 +85,10 @@ func fileShareAclAction(cmd *cobra.Command, args []string) {
 
 func fileShareAclCreateAction(cmd *cobra.Command, args []string) {
 	ArgsNumCheck(cmd, args, 1)
-
-	var accessCapability []string
-	if "" != shareAclAccessCapability {
-		err := json.Unmarshal([]byte(shareAclAccessCapability), &accessCapability)
-		if err != nil {
-			log.Fatalf("error parsing accessCapability %s: %+v", shareAclAccessCapability, err)
-		}
-	}
-
 	acl := &model.FileShareAclSpec{
 		FileShareId:      args[0],
 		Type:             shareAclType,
-		AccessCapability: accessCapability,
+		AccessCapability: shareAclAccessCapability,
 		AccessTo:         shareAclAccessTo,
 		Description:      shareAclDesp,
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
There was a CLI issue, we were not able to create ACL for given fileshare using CLI. But we were able to create ACL by using API. 
For more detail please take a look of #921 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
This PR will allow user to create fileshare acl for given fileshare. Below is the test screen report.
![acl1](https://user-images.githubusercontent.com/41313813/73934071-bba36a80-4903-11ea-8bef-748456498ffa.png)


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
