### PR TITLE
Apiserver ut's

### DIFF
--- a/pkg/api/controllers/fileshare_test.go
+++ b/pkg/api/controllers/fileshare_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/astaxie/beego"
 	"github.com/astaxie/beego/context"
@@ -29,6 +30,7 @@ import (
 	"github.com/sodafoundation/api/pkg/db"
 	"github.com/sodafoundation/api/pkg/model"
 	pb "github.com/sodafoundation/api/pkg/model/proto"
+	"github.com/sodafoundation/api/pkg/utils/constants"
 	. "github.com/sodafoundation/api/testutils/collection"
 	ctrtest "github.com/sodafoundation/api/testutils/controller/testing"
 	dbtest "github.com/sodafoundation/api/testutils/db/testing"
@@ -43,11 +45,15 @@ func init() {
 	beego.Router("/v1beta/file/shares/:fileshareId", NewFakeFileSharePortal(),
 		"get:GetFileShare;put:UpdateFileShare;delete:DeleteFileShare")
 
-	beego.Router("/v1beta/file/snapshots", &FileShareSnapshotPortal{},
+	beego.Router("/v1beta/file/snapshots", NewFakeFileShareSnapshotPortal(),
 		"post:CreateFileShareSnapshot;get:ListFileShareSnapshots")
-	beego.Router("/v1beta/file/snapshots/:snapshotId", &FileShareSnapshotPortal{},
+	beego.Router("/v1beta/file/snapshots/:snapshotId", NewFakeFileShareSnapshotPortal(),
 		"get:GetFileShareSnapshot;put:UpdateFileShareSnapshot;delete:DeleteFileShareSnapshot")
 
+	beego.Router("/v1beta/file/acls", NewFakeFileSharePortal(),
+		"post:CreateFileShareAcl;get:ListFileSharesAcl")
+	beego.Router("/v1beta/file/acls/:aclId", NewFakeFileSharePortal(),
+		"get:GetFileShareAcl;delete:DeleteFileShareAcl")
 }
 
 func NewFakeFileSharePortal() *FileSharePortal {
@@ -56,13 +62,71 @@ func NewFakeFileSharePortal() *FileSharePortal {
 	mockClient.On("Connect", "localhost:50049").Return(nil)
 	mockClient.On("Close").Return(nil)
 	mockClient.On("CreateFileShare", ctx.Background(), &pb.CreateFileShareOpts{
-		Context: c.NewAdminContext().ToJson(),
+		Id:               "d2975ebe-d82c-430f-b28e-f373746a71ca",
+		Name:             "sample-fileshare-01",
+		Size:             int64(1),
+		Description:      "This is first sample fileshare for testing",
+		AvailabilityZone: "default",
+		PoolId:           "a5965ebe-dg2c-434t-b28e-f373746a71ca",
+		Context:          c.NewAdminContext().ToJson(),
+		Profile:          SampleFileShareProfiles[0].ToJson(),
+		ExportLocations:  []string{"192.168.100.100"},
+		SnapshotId:       "b7602e18-771e-11e7-8f38-dbd6d291f4eg",
+		SnapshotName:     "sample-snapshot-01",
 	}).Return(&pb.GenericResponse{}, nil)
 	mockClient.On("DeleteFileShare", ctx.Background(), &pb.DeleteFileShareOpts{
-		Context: c.NewAdminContext().ToJson(),
+		Id:              "d2975ebe-d82c-430f-b28e-f373746a71ca",
+		PoolId:          "a5965ebe-dg2c-434t-b28e-f373746a71ca",
+		Context:         c.NewAdminContext().ToJson(),
+		Profile:         SampleFileShareProfiles[0].ToJson(),
+		ExportLocations: []string{"192.168.100.100"},
+	}).Return(&pb.GenericResponse{}, nil)
+	mockClient.On("CreateFileShareAcl", ctx.Background(), &pb.CreateFileShareAclOpts{
+		Id:               "6ad25d59-a160-45b2-8920-211be282e2df",
+		FileshareId:      "d2975ebe-d82c-430f-b28e-f373746a71ca",
+		Description:      "This is a sample Acl for testing",
+		Type:             "ip",
+		AccessCapability: []string{"Read", "Write"},
+		AccessTo:         "10.32.109.15",
+		Profile:          SampleFileShareProfiles[0].ToJson(),
+		Context:          c.NewAdminContext().ToJson(),
+	}).Return(&pb.GenericResponse{}, nil)
+	mockClient.On("DeleteFileShareAcl", ctx.Background(), &pb.DeleteFileShareAclOpts{
+		Id:               "6ad25d59-a160-45b2-8920-211be282e2df",
+		FileshareId:      "d2975ebe-d82c-430f-b28e-f373746a71ca",
+		Description:      "This is a sample Acl for testing",
+		Type:             "ip",
+		AccessCapability: []string{"Read", "Write"},
+		AccessTo:         "10.32.109.15",
+		Profile:          SampleFileShareProfiles[0].ToJson(),
+		Context:          c.NewAdminContext().ToJson(),
+		Metadata:         map[string]string{},
 	}).Return(&pb.GenericResponse{}, nil)
 
 	return &FileSharePortal{
+		CtrClient: mockClient,
+	}
+}
+
+func NewFakeFileShareSnapshotPortal() *FileShareSnapshotPortal {
+	mockClient := new(ctrtest.Client)
+	mockClient.On("Connect", "localhost:50049").Return(nil)
+	mockClient.On("Close").Return(nil)
+	mockClient.On("CreateFileShareSnapshot", ctx.Background(), &pb.CreateFileShareSnapshotOpts{
+		Id:          "3769855c-a102-11e7-b772-17b880d2f537",
+		Name:        "sample-snapshot-01",
+		Description: "This is the first sample snapshot for testing",
+		FileshareId: "d2975ebe-d82c-430f-b28e-f373746a71ca",
+		Context:     c.NewAdminContext().ToJson(),
+		Profile:     SampleFileShareProfiles[0].ToJson(),
+	}).Return(&pb.GenericResponse{}, nil)
+	mockClient.On("DeleteFileShareSnapshot", ctx.Background(), &pb.DeleteFileShareSnapshotOpts{
+		Id:          "3769855c-a102-11e7-b772-17b880d2f537",
+		FileshareId: "d2975ebe-d82c-430f-b28e-f373746a71ca",
+		Context:     c.NewAdminContext().ToJson(),
+		Profile:     SampleFileShareProfiles[0].ToJson(),
+	}).Return(&pb.GenericResponse{}, nil)
+	return &FileShareSnapshotPortal{
 		CtrClient: mockClient,
 	}
 }
@@ -226,6 +290,100 @@ func TestUpdateFileShare(t *testing.T) {
 	})
 }
 
+func TestCreateFileShare(t *testing.T) {
+	var jsonStr = []byte(`{
+		"id": "d2975ebe-d82c-430f-b28e-f373746a71ca",
+		"name":"sample-fileshare-01",
+		"description":"This is first sample fileshare for testing",
+		"size":1,
+		"poolId": "a5965ebe-dg2c-434t-b28e-f373746a71ca",
+		"snapshotId": "b7602e18-771e-11e7-8f38-dbd6d291f4eg"
+	}`)
+
+	t.Run("Should return 202 if everything works well", func(t *testing.T) {
+		fileshare := model.FileShareSpec{BaseModel: &model.BaseModel{}}
+		json.NewDecoder(bytes.NewBuffer(jsonStr)).Decode(&fileshare)
+		fileshare.CreatedAt = time.Now().Format(constants.TimeFormat)
+		fileshare.UpdatedAt = time.Now().Format(constants.TimeFormat)
+		fileshare.AvailabilityZone = "default"
+		fileshare.Status = "creating"
+		fileshare.ProfileId = "1106b972-66ef-11e7-b172-db03f3689c9c"
+		mockClient := new(dbtest.Client)
+		mockClient.On("GetDefaultProfileFileShare", c.NewAdminContext()).Return(&SampleFileShareProfiles[0], nil)
+		mockClient.On("GetFileShareSnapshot", c.NewAdminContext(), "b7602e18-771e-11e7-8f38-dbd6d291f4eg").Return(&SampleFileShareSnapshots[0], nil)
+		mockClient.On("GetFileShare", c.NewAdminContext(), "d2975ebe-d82c-430f-b28e-f373746a71ca").Return(&SampleFileShares[0], nil)
+		mockClient.On("CreateFileShare", c.NewAdminContext(), &fileshare).Return(&SampleFileShares[0], nil)
+		db.C = mockClient
+
+		r, _ := http.NewRequest("POST", "/v1beta/file/shares", bytes.NewBuffer(jsonStr))
+		w := httptest.NewRecorder()
+		r.Header.Set("Content-Type", "application/JSON")
+		beego.InsertFilter("*", beego.BeforeExec, func(httpCtx *context.Context) {
+			httpCtx.Input.SetData("context", c.NewAdminContext())
+		})
+		beego.BeeApp.Handlers.ServeHTTP(w, r)
+		var output model.FileShareSpec
+		json.Unmarshal(w.Body.Bytes(), &output)
+		assertTestResult(t, w.Code, 202)
+		assertTestResult(t, &output, &SampleFileShares[0])
+	})
+
+	t.Run("Should return 404 if create file share with bad request - Provided snapshot id not found in db", func(t *testing.T) {
+		fileshare := model.FileShareSpec{BaseModel: &model.BaseModel{}}
+		json.NewDecoder(bytes.NewBuffer(jsonStr)).Decode(&fileshare)
+		mockClient := new(dbtest.Client)
+		mockClient.On("GetDefaultProfileFileShare", c.NewAdminContext()).Return(&SampleFileShareProfiles[0], nil)
+		mockClient.On("GetFileShareSnapshot", c.NewAdminContext(), "b7602e18-771e-11e7-8f38-dbd6d291f4eg").Return(nil, errors.New("specified fileshare snapshot(b7602e18-771e-11e7-8f38-dbd6d291f4eg) can't find"))
+		db.C = mockClient
+
+		r, _ := http.NewRequest("POST", "/v1beta/file/shares", bytes.NewBuffer(jsonStr))
+		w := httptest.NewRecorder()
+		r.Header.Set("Content-Type", "application/JSON")
+		beego.InsertFilter("*", beego.BeforeExec, func(httpCtx *context.Context) {
+			httpCtx.Input.SetData("context", c.NewAdminContext())
+		})
+		beego.BeeApp.Handlers.ServeHTTP(w, r)
+		assertTestResult(t, w.Code, 404)
+	})
+}
+
+func TestDeleteFileShare(t *testing.T) {
+
+	t.Run("Should return 202 if delete file share is ok", func(t *testing.T) {
+		mockClient := new(dbtest.Client)
+		mockClient.On("GetFileShare", c.NewAdminContext(), "d2975ebe-d82c-430f-b28e-f373746a71ca").Return(&SampleFileShares[0], nil)
+		mockClient.On("GetProfile", c.NewAdminContext(), "b3585ebe-c42c-120g-b28e-f373746a71ca").Return(&SampleFileShareProfiles[0], nil)
+		mockClient.On("ListSnapshotsByShareId", c.NewAdminContext(), "d2975ebe-d82c-430f-b28e-f373746a71ca").Return(nil, nil)
+		mockClient.On("ListFileShareAclsByShareId", c.NewAdminContext(), "d2975ebe-d82c-430f-b28e-f373746a71ca").Return(nil, nil)
+		mockClient.On("UpdateFileShare", c.NewAdminContext(), &SampleFileShares[0]).Return(nil, nil)
+		mockClient.On("DeleteFileShare", c.NewAdminContext(), "d2975ebe-d82c-430f-b28e-f373746a71ca").Return(nil)
+		db.C = mockClient
+
+		r, _ := http.NewRequest("DELETE", "/v1beta/file/shares/d2975ebe-d82c-430f-b28e-f373746a71ca", nil)
+		w := httptest.NewRecorder()
+		beego.InsertFilter("*", beego.BeforeExec, func(httpCtx *context.Context) {
+			httpCtx.Input.SetData("context", c.NewAdminContext())
+		})
+		beego.BeeApp.Handlers.ServeHTTP(w, r)
+		assertTestResult(t, w.Code, 202)
+	})
+
+	t.Run("Should return 404 if delete file share with bad request - file share id not found", func(t *testing.T) {
+		mockClient := new(dbtest.Client)
+		mockClient.On("GetFileShare", c.NewAdminContext(), "d2975ebe-d82c-430f-b28e-f373746a71ca").Return(nil, errors.New("specified fileshare(d2975ebe-d82c-430f-b28e-f373746a71ca) can't find"))
+		db.C = mockClient
+
+		r, _ := http.NewRequest("DELETE",
+			"/v1beta/file/shares/d2975ebe-d82c-430f-b28e-f373746a71ca", nil)
+		w := httptest.NewRecorder()
+		beego.InsertFilter("*", beego.BeforeExec, func(httpCtx *context.Context) {
+			httpCtx.Input.SetData("context", c.NewAdminContext())
+		})
+		beego.BeeApp.Handlers.ServeHTTP(w, r)
+		assertTestResult(t, w.Code, 404)
+	})
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 //                      Tests for fileshare snapshot                          //
 ////////////////////////////////////////////////////////////////////////////////
@@ -366,5 +524,277 @@ func TestUpdateFileShareSnapshot(t *testing.T) {
 		})
 		beego.BeeApp.Handlers.ServeHTTP(w, r)
 		assertTestResult(t, w.Code, 500)
+	})
+}
+
+func TestCreateFileShareSnapshot(t *testing.T) {
+	var jsonStr = []byte(`{
+		"id": "3769855c-a102-11e7-b772-17b880d2f537",
+		"fileshareId": "d2975ebe-d82c-430f-b28e-f373746a71ca",
+		"name": "File_share_snapshot",
+		"description": "fake File share snapshot",
+		"profileId": "1106b972-66ef-11e7-b172-db03f3689c9c",
+		"shareSize": 1,
+		"snapshotSize": 1
+	}`)
+
+	t.Run("Should return 202 if everything works well", func(t *testing.T) {
+		snapshot := model.FileShareSnapshotSpec{BaseModel: &model.BaseModel{}}
+		json.NewDecoder(bytes.NewBuffer(jsonStr)).Decode(&snapshot)
+		snapshot.Status = "creating"
+		snapshot.CreatedAt = time.Now().Format(constants.TimeFormat)
+
+		mockClient := new(dbtest.Client)
+		mockClient.On("GetFileShare", c.NewAdminContext(), SampleFileShareSnapshots[0].FileShareId).Return(&SampleFileShares[1], nil)
+		mockClient.On("GetProfile", c.NewAdminContext(), "1106b972-66ef-11e7-b172-db03f3689c9c").Return(&SampleFileShareProfiles[0], nil)
+		mockClient.On("ListFileShareSnapshots", c.NewAdminContext()).Return(nil, nil)
+		mockClient.On("CreateFileShareSnapshot", c.NewAdminContext(), &snapshot).Return(&SampleFileShareSnapshots[0], nil)
+		db.C = mockClient
+
+		r, _ := http.NewRequest("POST", "/v1beta/file/snapshots", bytes.NewBuffer(jsonStr))
+		w := httptest.NewRecorder()
+		r.Header.Set("Content-Type", "application/JSON")
+		beego.InsertFilter("*", beego.BeforeExec, func(httpCtx *context.Context) {
+			httpCtx.Input.SetData("context", c.NewAdminContext())
+		})
+		beego.BeeApp.Handlers.ServeHTTP(w, r)
+		var output model.FileShareSnapshotSpec
+		json.Unmarshal(w.Body.Bytes(), &output)
+		assertTestResult(t, w.Code, 202)
+		assertTestResult(t, &output, &SampleFileShareSnapshots[0])
+	})
+
+	t.Run("Should return 404 if create file share snapshot with bad request - fileshare id which doesn't exists in db", func(t *testing.T) {
+		mockClient := new(dbtest.Client)
+		mockClient.On("GetFileShare", c.NewAdminContext(), SampleFileShareSnapshots[0].FileShareId).Return(nil, errors.New("specified fileshare (b7602e18-771e-11e7-8f38-dbd6d291f4eg) can't find"))
+		db.C = mockClient
+
+		r, _ := http.NewRequest("POST", "/v1beta/file/snapshots", bytes.NewBuffer(jsonStr))
+		w := httptest.NewRecorder()
+		r.Header.Set("Content-Type", "application/JSON")
+		beego.InsertFilter("*", beego.BeforeExec, func(httpCtx *context.Context) {
+			httpCtx.Input.SetData("context", c.NewAdminContext())
+		})
+		beego.BeeApp.Handlers.ServeHTTP(w, r)
+		assertTestResult(t, w.Code, 404)
+	})
+}
+
+func TestDeleteFileShareSnapshot(t *testing.T) {
+
+	t.Run("Should return 202 if everything works well", func(t *testing.T) {
+		mockClient := new(dbtest.Client)
+		mockClient.On("GetFileShareSnapshot", c.NewAdminContext(), "3769855c-a102-11e7-b772-17b880d2f537").Return(&SampleFileShareSnapshots[0], nil)
+		mockClient.On("GetProfile", c.NewAdminContext(), SampleFileShareSnapshots[0].ProfileId).Return(&SampleFileShareProfiles[0], nil)
+		mockClient.On("GetFileShare", c.NewAdminContext(), SampleFileShareSnapshots[0].FileShareId).Return(&SampleFileShares[0], nil)
+		mockClient.On("UpdateFileShareSnapshot", c.NewAdminContext(), SampleFileShareSnapshots[0].Id, &SampleFileShareSnapshots[0]).Return(nil, nil)
+		mockClient.On("DeleteFileShareSnapshot", c.NewAdminContext(), "3769855c-a102-11e7-b772-17b880d2f537").Return(nil)
+		db.C = mockClient
+
+		r, _ := http.NewRequest("DELETE",
+			"/v1beta/file/snapshots/3769855c-a102-11e7-b772-17b880d2f537", nil)
+		w := httptest.NewRecorder()
+		beego.InsertFilter("*", beego.BeforeExec, func(httpCtx *context.Context) {
+			httpCtx.Input.SetData("context", c.NewAdminContext())
+		})
+		beego.BeeApp.Handlers.ServeHTTP(w, r)
+		assertTestResult(t, w.Code, 202)
+	})
+
+	t.Run("Should return 404 if delete file share snapshot with bad request - snapshot id doesn't exist in db ", func(t *testing.T) {
+		mockClient := new(dbtest.Client)
+		mockClient.On("GetFileShareSnapshot", c.NewAdminContext(), "3769855c-a102-11e7-b772-17b880d2f537").Return(nil, errors.New("specified fileshare snapshot(b7602e18-771e-11e7-8f38-dbd6d291f4eg) can't find"))
+		db.C = mockClient
+
+		r, _ := http.NewRequest("DELETE",
+			"/v1beta/file/snapshots/3769855c-a102-11e7-b772-17b880d2f537", nil)
+		w := httptest.NewRecorder()
+		beego.InsertFilter("*", beego.BeforeExec, func(httpCtx *context.Context) {
+			httpCtx.Input.SetData("context", c.NewAdminContext())
+		})
+		beego.BeeApp.Handlers.ServeHTTP(w, r)
+		assertTestResult(t, w.Code, 404)
+	})
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//                      Tests for fileshare ACL                               //
+////////////////////////////////////////////////////////////////////////////////
+
+func TestCreateFileShareAcl(t *testing.T) {
+	var jsonStr = []byte(`{
+		"id": "6ad25d59-a160-45b2-8920-211be282e2df",
+		"fileshareId": "d2975ebe-d82c-430f-b28e-f373746a71ca",
+		"type": "ip",
+		"accessCapability": [
+			"Read", "Write"
+		],
+		"accessTo": "10.32.109.15",
+		"profileId": "1106b972-66ef-11e7-b172-db03f3689c9c",
+		"description": "This is a sample Acl for testing"
+	}`)
+
+	t.Run("Should return 202 if everything works well", func(t *testing.T) {
+		acl := model.FileShareAclSpec{BaseModel: &model.BaseModel{}}
+		json.NewDecoder(bytes.NewBuffer(jsonStr)).Decode(&acl)
+		acl.CreatedAt = time.Now().Format(constants.TimeFormat)
+		acl.UpdatedAt = time.Now().Format(constants.TimeFormat)
+		acl.Status = "available"
+		SampleFileShares[0].Status = "available"
+		acl.Metadata = map[string]string(nil)
+		mockClient := new(dbtest.Client)
+		mockClient.On("GetFileShare", c.NewAdminContext(), SampleFileSharesAcl[2].FileShareId).Return(&SampleFileShares[0], nil)
+		mockClient.On("GetProfile", c.NewAdminContext(), "1106b972-66ef-11e7-b172-db03f3689c9c").Return(&SampleFileShareProfiles[0], nil)
+		mockClient.On("CreateFileShareAcl", c.NewAdminContext(), &acl).Return(&SampleFileSharesAcl[2], nil)
+		db.C = mockClient
+
+		r, _ := http.NewRequest("POST", "/v1beta/file/acls", bytes.NewBuffer(jsonStr))
+		w := httptest.NewRecorder()
+		r.Header.Set("Content-Type", "application/JSON")
+		beego.InsertFilter("*", beego.BeforeExec, func(httpCtx *context.Context) {
+			httpCtx.Input.SetData("context", c.NewAdminContext())
+		})
+		beego.BeeApp.Handlers.ServeHTTP(w, r)
+		var output model.FileShareAclSpec
+		json.Unmarshal(w.Body.Bytes(), &output)
+		assertTestResult(t, w.Code, 202)
+		assertTestResult(t, &output, &SampleFileSharesAcl[2])
+	})
+
+	t.Run("Should return 400 if create file share acl with bad request - fileshare acl id which doesn't exists in db", func(t *testing.T) {
+		acl := model.FileShareAclSpec{BaseModel: &model.BaseModel{}}
+		json.NewDecoder(bytes.NewBuffer(jsonStr)).Decode(&acl)
+		acl.CreatedAt = time.Now().Format(constants.TimeFormat)
+		acl.UpdatedAt = time.Now().Format(constants.TimeFormat)
+		acl.Status = "available"
+		mockClient := new(dbtest.Client)
+		mockClient.On("GetFileShare", c.NewAdminContext(), SampleFileSharesAcl[2].FileShareId).Return(nil, errors.New("specified fileshare (b7602e18-771e-11e7-8f38-dbd6d291f4eg) can't find"))
+		db.C = mockClient
+
+		r, _ := http.NewRequest("POST", "/v1beta/file/acls", bytes.NewBuffer(jsonStr))
+		w := httptest.NewRecorder()
+		r.Header.Set("Content-Type", "application/JSON")
+		beego.InsertFilter("*", beego.BeforeExec, func(httpCtx *context.Context) {
+			httpCtx.Input.SetData("context", c.NewAdminContext())
+		})
+		beego.BeeApp.Handlers.ServeHTTP(w, r)
+		assertTestResult(t, w.Code, 400)
+	})
+}
+
+func TestListFileSharesAcl(t *testing.T) {
+	t.Run("Should return 200 if everything works well", func(t *testing.T) {
+		var sampleAcls = []*model.FileShareAclSpec{&SampleFileSharesAcl[0], &SampleFileSharesAcl[1]}
+		mockClient := new(dbtest.Client)
+		m := map[string][]string{
+			"offset":  {"0"},
+			"limit":   {"1"},
+			"sortDir": {"asc"},
+			"sortKey": {"name"},
+		}
+		mockClient.On("ListFileSharesAclWithFilter", c.NewAdminContext(), m).Return(sampleAcls, nil)
+		db.C = mockClient
+
+		r, _ := http.NewRequest("GET", "/v1beta/file/acls?offset=0&limit=1&sortDir=asc&sortKey=name", nil)
+		w := httptest.NewRecorder()
+		beego.InsertFilter("*", beego.BeforeExec, func(httpCtx *context.Context) {
+			httpCtx.Input.SetData("context", c.NewAdminContext())
+		})
+		beego.BeeApp.Handlers.ServeHTTP(w, r)
+
+		var output []*model.FileShareAclSpec
+		json.Unmarshal(w.Body.Bytes(), &output)
+		assertTestResult(t, w.Code, 200)
+		assertTestResult(t, output, sampleAcls)
+	})
+
+	t.Run("Should return 500 if list fileshare acl with bad request - db error to list acls", func(t *testing.T) {
+		mockClient := new(dbtest.Client)
+		m := map[string][]string{
+			"offset":  {"0"},
+			"limit":   {"1"},
+			"sortDir": {"asc"},
+			"sortKey": {"name"},
+		}
+		mockClient.On("ListFileSharesAclWithFilter", c.NewAdminContext(), m).Return(nil, errors.New("db error"))
+		db.C = mockClient
+
+		r, _ := http.NewRequest("GET", "/v1beta/file/acls?offset=0&limit=1&sortDir=asc&sortKey=name", nil)
+		w := httptest.NewRecorder()
+		beego.InsertFilter("*", beego.BeforeExec, func(httpCtx *context.Context) {
+			httpCtx.Input.SetData("context", c.NewAdminContext())
+		})
+		beego.BeeApp.Handlers.ServeHTTP(w, r)
+		assertTestResult(t, w.Code, 500)
+	})
+}
+
+func TestGetFileShareAcl(t *testing.T) {
+	t.Run("Should return 200 if everything works well", func(t *testing.T) {
+		mockClient := new(dbtest.Client)
+		mockClient.On("GetFileShareAcl", c.NewAdminContext(), "6ad25d59-a160-45b2-8920-211be282e2df").Return(&SampleFileSharesAcl[2], nil)
+		db.C = mockClient
+
+		r, _ := http.NewRequest("GET", "/v1beta/file/acls/6ad25d59-a160-45b2-8920-211be282e2df", nil)
+		w := httptest.NewRecorder()
+		beego.InsertFilter("*", beego.BeforeExec, func(httpCtx *context.Context) {
+			httpCtx.Input.SetData("context", c.NewAdminContext())
+		})
+		beego.BeeApp.Handlers.ServeHTTP(w, r)
+		var output model.FileShareAclSpec
+		json.Unmarshal(w.Body.Bytes(), &output)
+		assertTestResult(t, w.Code, 200)
+		assertTestResult(t, &output, &SampleFileSharesAcl[2])
+	})
+
+	t.Run("Should return 404 if get fileshare acl with bad request - acl id not found in db", func(t *testing.T) {
+		mockClient := new(dbtest.Client)
+		mockClient.On("GetFileShareAcl", c.NewAdminContext(), "6ad25d59-a160-45b2-8920-211be282e2df").Return(nil, errors.New("specified fileshare snapshot(6ad25d59-a160-45b2-8920-211be282e2df) can't find"))
+		db.C = mockClient
+
+		r, _ := http.NewRequest("GET", "/v1beta/file/acls/6ad25d59-a160-45b2-8920-211be282e2df", nil)
+		w := httptest.NewRecorder()
+		beego.InsertFilter("*", beego.BeforeExec, func(httpCtx *context.Context) {
+			httpCtx.Input.SetData("context", c.NewAdminContext())
+		})
+		beego.BeeApp.Handlers.ServeHTTP(w, r)
+		assertTestResult(t, w.Code, 404)
+	})
+}
+
+func TestDeleteFileShareAcl(t *testing.T) {
+	t.Run("Should return 202 if everything works well", func(t *testing.T) {
+		SampleFileSharesAcl[2].Status = "available"
+		mockClient := new(dbtest.Client)
+		mockClient.On("GetFileShareAcl", c.NewAdminContext(), "6ad25d59-a160-45b2-8920-211be282e2df").Return(&SampleFileSharesAcl[2], nil)
+		mockClient.On("GetProfile", c.NewAdminContext(), "b3585ebe-c42c-120g-b28e-f373746a71ca").Return(&SampleFileShareProfiles[0], nil)
+		mockClient.On("GetFileShare", c.NewAdminContext(), SampleFileSharesAcl[2].FileShareId).Return(&SampleFileShares[0], nil)
+		mockClient.On("UpdateFileShareAcl", c.NewAdminContext(), &SampleFileSharesAcl[2]).Return(nil, nil)
+		mockClient.On("DeleteFileShareAcl", c.NewAdminContext(), "6ad25d59-a160-45b2-8920-211be282e2df").Return(nil)
+		db.C = mockClient
+
+		r, _ := http.NewRequest("DELETE",
+			"/v1beta/file/acls/6ad25d59-a160-45b2-8920-211be282e2df", nil)
+		w := httptest.NewRecorder()
+		beego.InsertFilter("*", beego.BeforeExec, func(httpCtx *context.Context) {
+			httpCtx.Input.SetData("context", c.NewAdminContext())
+		})
+		beego.BeeApp.Handlers.ServeHTTP(w, r)
+		assertTestResult(t, w.Code, 202)
+	})
+
+	t.Run("Should return 404 if delete file share acl with bad request - invalid file share acl id", func(t *testing.T) {
+		mockClient := new(dbtest.Client)
+		mockClient.On("GetFileShareAcl", c.NewAdminContext(), "6ad25d59-a160-45b2-8920-211be282e2df").Return(nil, errors.New("specified fileshare acl(6ad25d59-a160-45b2-8920-211be282e2df) can't find"))
+		db.C = mockClient
+
+		r, _ := http.NewRequest("DELETE",
+			"/v1beta/file/acls/6ad25d59-a160-45b2-8920-211be282e2df", nil)
+		w := httptest.NewRecorder()
+		beego.InsertFilter("*", beego.BeforeExec, func(httpCtx *context.Context) {
+			httpCtx.Input.SetData("context", c.NewAdminContext())
+		})
+		beego.BeeApp.Handlers.ServeHTTP(w, r)
+		assertTestResult(t, w.Code, 404)
 	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind new feature
> /kind bug fix
> /kind cleanup
> /kind revert change
> /kind design
> /kind documentation
> /kind enhancement

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Test Report Added?**: Yes
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind TESTED
> /kind NOT-TESTED

**Test Report**:
<!--
*Please provide the test report link (public accessible, screen shot or copy paste the test report, 
or add the testing details.
-->
fileshare_test report
```
=== RUN   TestListFileShares
--- PASS: TestListFileShares (0.00s)
=== RUN   TestListFileShares/Should_return_200_if_everything_works_well
    --- PASS: TestListFileShares/Should_return_200_if_everything_works_well (0.00s)
=== RUN   TestListFileShares/Should_return_500_if_list_file_share_with_bad_request
E0925 23:36:26.115041    3265 base.go:96] list fileshares failed: db error
    --- PASS: TestListFileShares/Should_return_500_if_list_file_share_with_bad_request (0.00s)
=== RUN   TestGetFileShare
--- PASS: TestGetFileShare (0.00s)
=== RUN   TestGetFileShare/Should_return_200_if_everything_works_well
    --- PASS: TestGetFileShare/Should_return_200_if_everything_works_well (0.00s)
=== RUN   TestGetFileShare/Should_return_404_if_get_file_share_replication_with_bad_request
E0925 23:36:26.117369    3265 base.go:96] fileshare bd5b12a8-a101-11e7-941e-d77981b584d8 not found: db error
    --- PASS: TestGetFileShare/Should_return_404_if_get_file_share_replication_with_bad_request (0.00s)
=== RUN   TestUpdateFileShare
--- PASS: TestUpdateFileShare (0.00s)
=== RUN   TestUpdateFileShare/Should_return_200_if_everything_works_well
    --- PASS: TestUpdateFileShare/Should_return_200_if_everything_works_well (0.00s)
=== RUN   TestUpdateFileShare/Should_return_500_if_update_file_share_with_bad_request
E0925 23:36:26.119684    3265 base.go:96] update fileshare failed: db error
    --- PASS: TestUpdateFileShare/Should_return_500_if_update_file_share_with_bad_request (0.00s)
=== RUN   TestCreateFileShare
--- PASS: TestCreateFileShare (0.00s)
=== RUN   TestCreateFileShare/Should_return_202_if_everything_works_well
    --- PASS: TestCreateFileShare/Should_return_202_if_everything_works_well (0.00s)
=== RUN   TestCreateFileShare/Should_return_404_if_create_file_share_with_bad_request_-_Provided_snapshot_id_not_found_in_db
E0925 23:36:26.122560    3265 base.go:96] give valid snapshotId b7602e18-771e-11e7-8f38-dbd6d291f4eg. specified fileshare snapshot(b7602e18-771e-11e7-8f38-dbd6d291f4eg) can't find
    --- PASS: TestCreateFileShare/Should_return_404_if_create_file_share_with_bad_request_-_Provided_snapshot_id_not_found_in_db (0.00s)
=== RUN   TestDeleteFileShare
--- PASS: TestDeleteFileShare (0.00s)
=== RUN   TestDeleteFileShare/Should_return_202_if_delete_file_share_is_ok
    --- PASS: TestDeleteFileShare/Should_return_202_if_delete_file_share_is_ok (0.00s)
=== RUN   TestDeleteFileShare/Should_return_404_if_delete_file_share_with_bad_request_-_file_share_id_not_found
E0925 23:36:26.126121    3265 base.go:96] fileshare d2975ebe-d82c-430f-b28e-f373746a71ca not found: specified fileshare(d2975ebe-d82c-430f-b28e-f373746a71ca) can't find
    --- PASS: TestDeleteFileShare/Should_return_404_if_delete_file_share_with_bad_request_-_file_share_id_not_found (0.00s)
=== RUN   TestListFileShareSnapshots
--- PASS: TestListFileShareSnapshots (0.01s)
=== RUN   TestListFileShareSnapshots/Should_return_200_if_everything_works_well
    --- PASS: TestListFileShareSnapshots/Should_return_200_if_everything_works_well (0.01s)
=== RUN   TestListFileShareSnapshots/Should_return_500_if_list_fileshare_snapshots_with_bad_request
E0925 23:36:26.135159    3265 base.go:96] list fileshare snapshots failed: db error
    --- PASS: TestListFileShareSnapshots/Should_return_500_if_list_fileshare_snapshots_with_bad_request (0.00s)
=== RUN   TestGetFileShareSnapshot
--- PASS: TestGetFileShareSnapshot (0.00s)
=== RUN   TestGetFileShareSnapshot/Should_return_200_if_everything_works_well
    --- PASS: TestGetFileShareSnapshot/Should_return_200_if_everything_works_well (0.00s)
=== RUN   TestGetFileShareSnapshot/Should_return_404_if_get_fileshare_group_with_bad_request
E0925 23:36:26.137314    3265 base.go:96] fileshare snapshot 3769855c-a102-11e7-b772-17b880d2f537 not found: db error
    --- PASS: TestGetFileShareSnapshot/Should_return_404_if_get_fileshare_group_with_bad_request (0.00s)
=== RUN   TestUpdateFileShareSnapshot
--- PASS: TestUpdateFileShareSnapshot (0.00s)
=== RUN   TestUpdateFileShareSnapshot/Should_return_200_if_everything_works_well
    --- PASS: TestUpdateFileShareSnapshot/Should_return_200_if_everything_works_well (0.00s)
=== RUN   TestUpdateFileShareSnapshot/Should_return_500_if_update_fileshare_snapshot_with_bad_request
E0925 23:36:26.140219    3265 base.go:96] update fileshare snapshot failed: db error
    --- PASS: TestUpdateFileShareSnapshot/Should_return_500_if_update_fileshare_snapshot_with_bad_request (0.00s)
=== RUN   TestCreateFileShareSnapshot
--- PASS: TestCreateFileShareSnapshot (0.01s)
=== RUN   TestCreateFileShareSnapshot/Should_return_202_if_everything_works_well
    --- PASS: TestCreateFileShareSnapshot/Should_return_202_if_everything_works_well (0.01s)
=== RUN   TestCreateFileShareSnapshot/Should_return_404_if_create_file_share_snapshot_with_bad_request_-_fileshare_id_which_doesn't_exists_in_db
E0925 23:36:26.146214    3265 base.go:96] fileshare d2975ebe-d82c-430f-b28e-f373746a71ca not found: specified fileshare (b7602e18-771e-11e7-8f38-dbd6d291f4eg) can't find
    --- PASS: TestCreateFileShareSnapshot/Should_return_404_if_create_file_share_snapshot_with_bad_request_-_fileshare_id_which_doesn't_exists_in_db (0.00s)
=== RUN   TestDeleteFileShareSnapshot
--- PASS: TestDeleteFileShareSnapshot (0.00s)
=== RUN   TestDeleteFileShareSnapshot/Should_return_202_if_everything_works_well
    --- PASS: TestDeleteFileShareSnapshot/Should_return_202_if_everything_works_well (0.00s)
=== RUN   TestDeleteFileShareSnapshot/Should_return_404_if_delete_file_share_snapshot_with_bad_request_-_snapshot_id_doesn't_exist_in_db_
E0925 23:36:26.148349    3265 base.go:96] fileshare snapshot 3769855c-a102-11e7-b772-17b880d2f537 not found: specified fileshare snapshot(b7602e18-771e-11e7-8f38-dbd6d291f4eg) can't find
    --- PASS: TestDeleteFileShareSnapshot/Should_return_404_if_delete_file_share_snapshot_with_bad_request_-_snapshot_id_doesn't_exist_in_db_ (0.00s)
=== RUN   TestCreateFileShareAcl
--- PASS: TestCreateFileShareAcl (0.00s)
=== RUN   TestCreateFileShareAcl/Should_return_202_if_everything_works_well
    --- PASS: TestCreateFileShareAcl/Should_return_202_if_everything_works_well (0.00s)
=== RUN   TestCreateFileShareAcl/Should_return_400_if_create_file_share_acl_with_bad_request_-_fileshare_acl_id_which_doesn't_exists_in_db
E0925 23:36:26.150643    3265 base.go:96] getFileshare failed in create fileshare acl: specified fileshare (b7602e18-771e-11e7-8f38-dbd6d291f4eg) can't find
E0925 23:36:26.150714    3265 fileshare.go:69] getFileshare failed in create fileshare acl: specified fileshare (b7602e18-771e-11e7-8f38-dbd6d291f4eg) can't find
    --- PASS: TestCreateFileShareAcl/Should_return_400_if_create_file_share_acl_with_bad_request_-_fileshare_acl_id_which_doesn't_exists_in_db (0.00s)
=== RUN   TestListFileSharesAcl
--- PASS: TestListFileSharesAcl (0.00s)
=== RUN   TestListFileSharesAcl/Should_return_200_if_everything_works_well
    --- PASS: TestListFileSharesAcl/Should_return_200_if_everything_works_well (0.00s)
=== RUN   TestListFileSharesAcl/Should_return_500_if_list_fileshare_acl_with_bad_request_-_db_error_to_list_acls
E0925 23:36:26.151985    3265 base.go:96] list fileshares failed: db error
    --- PASS: TestListFileSharesAcl/Should_return_500_if_list_fileshare_acl_with_bad_request_-_db_error_to_list_acls (0.00s)
=== RUN   TestGetFileShareAcl
--- PASS: TestGetFileShareAcl (0.00s)
=== RUN   TestGetFileShareAcl/Should_return_200_if_everything_works_well
    --- PASS: TestGetFileShareAcl/Should_return_200_if_everything_works_well (0.00s)
=== RUN   TestGetFileShareAcl/Should_return_404_if_get_fileshare_acl_with_bad_request_-_acl_id_not_found_in_db
E0925 23:36:26.153262    3265 base.go:96] fileshare acl 6ad25d59-a160-45b2-8920-211be282e2df not found: specified fileshare snapshot(6ad25d59-a160-45b2-8920-211be282e2df) can't find
    --- PASS: TestGetFileShareAcl/Should_return_404_if_get_fileshare_acl_with_bad_request_-_acl_id_not_found_in_db (0.00s)
=== RUN   TestDeleteFileShareAcl
--- PASS: TestDeleteFileShareAcl (0.00s)
=== RUN   TestDeleteFileShareAcl/Should_return_202_if_everything_works_well
    --- PASS: TestDeleteFileShareAcl/Should_return_202_if_everything_works_well (0.00s)
=== RUN   TestDeleteFileShareAcl/Should_return_404_if_delete_file_share_acl_with_bad_request_-_invalid_file_share_acl_id
E0925 23:36:26.155525    3265 base.go:96] fileshare acl 6ad25d59-a160-45b2-8920-211be282e2df not found: specified fileshare acl(6ad25d59-a160-45b2-8920-211be282e2df) can't find
    --- PASS: TestDeleteFileShareAcl/Should_return_404_if_delete_file_share_acl_with_bad_request_-_invalid_file_share_acl_id (0.00s)
=== RUN   TestGetFileShareProfile
--- PASS: TestGetFileShareProfile (0.00s)
=== RUN   TestGetFileShareProfile/Should_return_200_if_everything_works_well
    --- PASS: TestGetFileShareProfile/Should_return_200_if_everything_works_well (0.00s)
=== RUN   TestGetFileShareProfile/Should_return_404_if_get_profile_with_bad_request
E0925 23:36:26.156891    3265 base.go:96] profile 2f9c0a04-66ef-11e7-ade2-43158893e017 not found: db error
    --- PASS: TestGetFileShareProfile/Should_return_404_if_get_profile_with_bad_request (0.00s)
=== RUN   TestDeleteFileShareProfile
--- PASS: TestDeleteFileShareProfile (0.00s)
=== RUN   TestDeleteFileShareProfile/Should_return_200_if_everything_works_well
    --- PASS: TestDeleteFileShareProfile/Should_return_200_if_everything_works_well (0.00s)
=== RUN   TestDeleteFileShareProfile/Should_return_404_if_delete_profile_with_bad_request
E0925 23:36:26.158863    3265 base.go:96] profile 2f9c0a04-66ef-11e7-ade2-43158893e017 not found: Invalid resource uuid
    --- PASS: TestDeleteFileShareProfile/Should_return_404_if_delete_profile_with_bad_request (0.00s)
PASS

Process finished with exit code 0

```

pool test report
```
=== RUN   TestListAvailabilityZones
--- PASS: TestListAvailabilityZones (0.00s)
=== RUN   TestListAvailabilityZones/Should_return_200_if_everything_works_well
    --- PASS: TestListAvailabilityZones/Should_return_200_if_everything_works_well (0.00s)
=== RUN   TestListAvailabilityZones/Should_return_500_-_get_AvailabilityZones_for_pools_failed_as_db_error
E0925 23:38:12.852511    3403 base.go:96] get AvailabilityZones for pools failed: get AvailabilityZones for pools failed:
    --- PASS: TestListAvailabilityZones/Should_return_500_-_get_AvailabilityZones_for_pools_failed_as_db_error (0.00s)
=== RUN   TestListPools
--- PASS: TestListPools (0.00s)
=== RUN   TestListPools/Should_return_200_if_everything_works_well
    --- PASS: TestListPools/Should_return_200_if_everything_works_well (0.00s)
=== RUN   TestListPools/Should_return_500_if_list_pools_with_bad_request
E0925 23:38:12.853445    3403 base.go:96] list pools failed: db error
    --- PASS: TestListPools/Should_return_500_if_list_pools_with_bad_request (0.00s)
=== RUN   TestGetPool
--- PASS: TestGetPool (0.00s)
=== RUN   TestGetPool/Should_return_200_if_everything_works_well
    --- PASS: TestGetPool/Should_return_200_if_everything_works_well (0.00s)
=== RUN   TestGetPool/Should_return_404_if_get_docks_with_bad_request
E0925 23:38:12.853790    3403 base.go:96] pool f4486139-78d5-462d-a7b9-fdaf6c797e1b not found: db error
    --- PASS: TestGetPool/Should_return_404_if_get_docks_with_bad_request (0.00s)
PASS

Process finished with exit code 0
```

host test report
```
=== RUN   TestCreateHost
--- PASS: TestCreateHost (0.01s)
=== RUN   TestCreateHost/Should_return_200_if_everything_works_well
    --- PASS: TestCreateHost/Should_return_200_if_everything_works_well (0.00s)
=== RUN   TestCreateHost/Should_return_400_for_invalid_request_-_lists_not_found_db_error
E0925 23:39:02.380234    3605 base.go:96] check host sap1 failed in CreateHost method: List hosts failed: 
    --- PASS: TestCreateHost/Should_return_400_for_invalid_request_-_lists_not_found_db_error (0.00s)
=== RUN   TestCreateHost/Should_return_400_-_for_some_db_error_while_creating_host
E0925 23:39:02.382395    3605 base.go:96] create host failed: db error
    --- PASS: TestCreateHost/Should_return_400_-_for_some_db_error_while_creating_host (0.00s)
=== RUN   TestCreateHost/Should_return_400_-_the_host_with_same_name_already_exists_in_the_system
E0925 23:39:02.383066    3605 base.go:96] the host with name sap1 already exists in the system
    --- PASS: TestCreateHost/Should_return_400_-_the_host_with_same_name_already_exists_in_the_system (0.00s)
=== RUN   TestListHosts
--- PASS: TestListHosts (0.00s)
=== RUN   TestListHosts/Should_return_200_if_everything_works_well
    --- PASS: TestListHosts/Should_return_200_if_everything_works_well (0.00s)
=== RUN   TestListHosts/Should_return_400_-_when_lists_fails_with_db_error
E0925 23:39:02.384873    3605 base.go:96] list hosts failed: When list hosts in db:
    --- PASS: TestListHosts/Should_return_400_-_when_lists_fails_with_db_error (0.00s)
=== RUN   TestGetHost
--- PASS: TestGetHost (0.00s)
=== RUN   TestGetHost/Should_return_200_if_everything_works_well
    --- PASS: TestGetHost/Should_return_200_if_everything_works_well (0.00s)
=== RUN   TestGetHost/Should_return_404_-_specified_host_id_doesn't_exists_in_db
E0925 23:39:02.386505    3605 base.go:96] host 202964b5-8e73-46fd-b41b-a8e403f3c30b not found: specified host(202964b5-8e73-46fd-b41b-a8e403f3c30b) can't find
    --- PASS: TestGetHost/Should_return_404_-_specified_host_id_doesn't_exists_in_db (0.00s)
=== RUN   TestUpdateHost
--- PASS: TestUpdateHost (0.00s)
=== RUN   TestUpdateHost/Should_return_200_if_everything_works_well
    --- PASS: TestUpdateHost/Should_return_200_if_everything_works_well (0.00s)
=== RUN   TestUpdateHost/Should_return_400_-_update_host_failed_with_db_error
E0925 23:39:02.388250    3605 base.go:96] update host failed: update host failed:
    --- PASS: TestUpdateHost/Should_return_400_-_update_host_failed_with_db_error (0.00s)
=== RUN   TestDeleteHost
--- PASS: TestDeleteHost (0.00s)
=== RUN   TestDeleteHost/Should_return_200_if_everything_works_well
    --- PASS: TestDeleteHost/Should_return_200_if_everything_works_well (0.00s)
PASS

Process finished with exit code 0

```
volume test report
```
=== RUN   TestGetVolumeAttachment
--- PASS: TestGetVolumeAttachment (0.01s)
=== RUN   TestGetVolumeAttachment/Should_return_200_if_everything_works_well
    --- PASS: TestGetVolumeAttachment/Should_return_200_if_everything_works_well (0.00s)
=== RUN   TestGetVolumeAttachment/Should_return_404_if_get_volume_attachment_with_bad_request
E0925 23:39:36.150911    3795 base.go:96] volume attachment f2dda3d2-bf79-11e7-8665-f750b088f63e not found: db error
    --- PASS: TestGetVolumeAttachment/Should_return_404_if_get_volume_attachment_with_bad_request (0.00s)
=== RUN   TestUpdateVolumeAttachment
--- PASS: TestUpdateVolumeAttachment (0.00s)
=== RUN   TestUpdateVolumeAttachment/Should_return_200_if_everything_works_well
    --- PASS: TestUpdateVolumeAttachment/Should_return_200_if_everything_works_well (0.00s)
=== RUN   TestUpdateVolumeAttachment/Should_return_500_if_update_volume_attachment_with_bad_request
E0925 23:39:36.152720    3795 base.go:96] update volume attachment failed: db error
    --- PASS: TestUpdateVolumeAttachment/Should_return_500_if_update_volume_attachment_with_bad_request (0.00s)
=== RUN   TestCreateVolumeGroup
--- PASS: TestCreateVolumeGroup (0.00s)
=== RUN   TestCreateVolumeGroup/Should_return_202_if_everything_works_well
    --- PASS: TestCreateVolumeGroup/Should_return_202_if_everything_works_well (0.00s)
=== RUN   TestCreateVolumeGroup/Should_return_400_if_create_volume_group_with_bad_request
E0925 23:39:36.155787    3795 base.go:96] create volume group failed: db error
    --- PASS: TestCreateVolumeGroup/Should_return_400_if_create_volume_group_with_bad_request (0.00s)
=== RUN   TestGetVolumeGroup
--- PASS: TestGetVolumeGroup (0.00s)
=== RUN   TestGetVolumeGroup/Should_return_200_if_everything_works_well
    --- PASS: TestGetVolumeGroup/Should_return_200_if_everything_works_well (0.00s)
=== RUN   TestGetVolumeGroup/Should_return_404_if_get_volume_group_resource_does_not_exist
E0925 23:39:36.156631    3795 base.go:96] volume group 3769855c-a102-11e7-b772-17b880d2f555 not found: db error
    --- PASS: TestGetVolumeGroup/Should_return_404_if_get_volume_group_resource_does_not_exist (0.00s)
=== RUN   TestUpdateVolumeGroup
--- PASS: TestUpdateVolumeGroup (0.00s)
=== RUN   TestUpdateVolumeGroup/Should_return_202_if_everything_works_well
    --- PASS: TestUpdateVolumeGroup/Should_return_202_if_everything_works_well (0.00s)
=== RUN   TestUpdateVolumeGroup/Should_return_400_if_update_volume_fails_with_bad_request
E0925 23:39:36.158205    3795 db.go:770] update group bd5b12a8-a101-11e7-941e-d77981b584d8 faild, because no valid name, description, addvolumes or removevolumes were provided
E0925 23:39:36.158284    3795 base.go:96] update volume group failed: update group bd5b12a8-a101-11e7-941e-d77981b584d8 faild, because no valid name, description, addvolumes or removevolumes were provided
    --- PASS: TestUpdateVolumeGroup/Should_return_400_if_update_volume_fails_with_bad_request (0.00s)
=== RUN   TestUpdateVolumeGroup/Should_return_400_if_update_volume_fails_with_bad_request_-_volume_group_not_found
E0925 23:39:36.158680    3795 base.go:96] update volume group failed: volume group bd5b12a8-a101-11e7-941e-d77981b584d8 not found:
    --- PASS: TestUpdateVolumeGroup/Should_return_400_if_update_volume_fails_with_bad_request_-_volume_group_not_found (0.00s)
=== RUN   TestDeleteVolumeGroup
--- PASS: TestDeleteVolumeGroup (0.00s)
=== RUN   TestDeleteVolumeGroup/Should_return_202_if_everything_works_well
    --- PASS: TestDeleteVolumeGroup/Should_return_202_if_everything_works_well (0.00s)
=== RUN   TestDeleteVolumeGroup/Should_return_404_-_specified_volume_group_id_can't_find_in_db
E0925 23:39:36.160260    3795 base.go:96] volume group 3769855c-a102-11e7-b772-17b880d2f555 not found: volume group 3769855c-a102-11e7-b772-17b880d2f555 not found: When get volume group in db
    --- PASS: TestDeleteVolumeGroup/Should_return_404_-_specified_volume_group_id_can't_find_in_db (0.00s)
=== RUN   TestListVolumes
--- PASS: TestListVolumes (0.00s)
=== RUN   TestListVolumes/Should_return_200_if_everything_works_well
    --- PASS: TestListVolumes/Should_return_200_if_everything_works_well (0.00s)
=== RUN   TestListVolumes/Should_return_500_if_list_volume_with_bad_request
E0925 23:39:36.160824    3795 base.go:96] list volumes failed: db error
    --- PASS: TestListVolumes/Should_return_500_if_list_volume_with_bad_request (0.00s)
=== RUN   TestGetVolume
--- PASS: TestGetVolume (0.00s)
=== RUN   TestGetVolume/Should_return_200_if_everything_works_well
    --- PASS: TestGetVolume/Should_return_200_if_everything_works_well (0.00s)
=== RUN   TestGetVolume/Should_return_404_if_get_volume_replication_with_bad_request
E0925 23:39:36.161252    3795 base.go:96] volume bd5b12a8-a101-11e7-941e-d77981b584d8 not found: db error
    --- PASS: TestGetVolume/Should_return_404_if_get_volume_replication_with_bad_request (0.00s)
=== RUN   TestUpdateVolume
--- PASS: TestUpdateVolume (0.00s)
=== RUN   TestUpdateVolume/Should_return_200_if_everything_works_well
    --- PASS: TestUpdateVolume/Should_return_200_if_everything_works_well (0.00s)
=== RUN   TestUpdateVolume/Should_return_500_if_update_volume_with_bad_request
E0925 23:39:36.161766    3795 base.go:96] update volume failed: db error
    --- PASS: TestUpdateVolume/Should_return_500_if_update_volume_with_bad_request (0.00s)
=== RUN   TestExtendVolume
--- PASS: TestExtendVolume (0.00s)
=== RUN   TestExtendVolume/Should_return_200_if_everything_works_well
    --- PASS: TestExtendVolume/Should_return_200_if_everything_works_well (0.00s)
=== RUN   TestExtendVolume/Should_return_400_if_extend_volume_with_bad_request
E0925 23:39:36.162796    3795 db.go:453] the status of the volume to be extended must be available!
E0925 23:39:36.162815    3795 base.go:96] extend volume failed: the status of the volume to be extended must be available!
    --- PASS: TestExtendVolume/Should_return_400_if_extend_volume_with_bad_request (0.00s)
=== RUN   TestCreateVolume
--- PASS: TestCreateVolume (0.00s)
=== RUN   TestCreateVolume/Should_return_202_if_everything_works_well
    --- PASS: TestCreateVolume/Should_return_202_if_everything_works_well (0.00s)
=== RUN   TestCreateVolume/Should_return_400_-_get_default_profile_failed:_db_error
E0925 23:39:36.163804    3795 base.go:96] get default profile failed: get default profile failed:
    --- PASS: TestCreateVolume/Should_return_400_-_get_default_profile_failed:_db_error (0.00s)
=== RUN   TestCreateVolume/Should_return_400_-_get_profile_failed:_db_error
E0925 23:39:36.164079    3795 base.go:96] get profile failed: get profile failed:
    --- PASS: TestCreateVolume/Should_return_400_-_get_profile_failed:_db_error (0.00s)
=== RUN   TestCreateVolume/Should_return_400_-_get_default_profile_failed:_db_error#01
E0925 23:39:36.164465    3795 base.go:96] create volume failed: create volume failed:
    --- PASS: TestCreateVolume/Should_return_400_-_get_default_profile_failed:_db_error#01 (0.00s)
=== RUN   TestDeleteVolume
--- PASS: TestDeleteVolume (0.00s)
=== RUN   TestDeleteVolume/Should_return_202_if_everything_works_well
    --- PASS: TestDeleteVolume/Should_return_202_if_everything_works_well (0.00s)
=== RUN   TestDeleteVolume/Should_return_404_-_Get_volume_id_failed:_db_error_
E0925 23:39:36.166390    3795 base.go:96] volume bd5b12a8-a101-11e7-941e-d77981b584d8 not found: specified volume(bd5b12a8-a101-11e7-941e-d77981b584d8) can't find
    --- PASS: TestDeleteVolume/Should_return_404_-_Get_volume_id_failed:_db_error_ (0.00s)
=== RUN   TestListVolumeSnapshots
--- PASS: TestListVolumeSnapshots (0.00s)
=== RUN   TestListVolumeSnapshots/Should_return_200_if_everything_works_well
    --- PASS: TestListVolumeSnapshots/Should_return_200_if_everything_works_well (0.00s)
=== RUN   TestListVolumeSnapshots/Should_return_500_if_list_volume_snapshots_with_bad_request
E0925 23:39:36.167475    3795 base.go:96] list volume snapshots failed: db error
    --- PASS: TestListVolumeSnapshots/Should_return_500_if_list_volume_snapshots_with_bad_request (0.00s)
=== RUN   TestGetVolumeSnapshot
--- PASS: TestGetVolumeSnapshot (0.00s)
=== RUN   TestGetVolumeSnapshot/Should_return_200_if_everything_works_well
    --- PASS: TestGetVolumeSnapshot/Should_return_200_if_everything_works_well (0.00s)
=== RUN   TestGetVolumeSnapshot/Should_return_404_if_get_volume_group_with_bad_request
E0925 23:39:36.168455    3795 base.go:96] volume snapshot 3769855c-a102-11e7-b772-17b880d2f537 not found: db error
    --- PASS: TestGetVolumeSnapshot/Should_return_404_if_get_volume_group_with_bad_request (0.00s)
=== RUN   TestUpdateVolumeSnapshot
--- PASS: TestUpdateVolumeSnapshot (0.00s)
=== RUN   TestUpdateVolumeSnapshot/Should_return_200_if_everything_works_well
    --- PASS: TestUpdateVolumeSnapshot/Should_return_200_if_everything_works_well (0.00s)
=== RUN   TestUpdateVolumeSnapshot/Should_return_500_if_update_volume_snapshot_with_bad_request
E0925 23:39:36.170112    3795 base.go:96] update volume snapshot failed: db error
    --- PASS: TestUpdateVolumeSnapshot/Should_return_500_if_update_volume_snapshot_with_bad_request (0.00s)
PASS

Process finished with exit code 0
```

volume group test report
```
=== RUN   TestCreateVolumeGroup
--- PASS: TestCreateVolumeGroup (0.00s)
=== RUN   TestCreateVolumeGroup/Should_return_202_if_everything_works_well
    --- PASS: TestCreateVolumeGroup/Should_return_202_if_everything_works_well (0.00s)
=== RUN   TestCreateVolumeGroup/Should_return_400_if_create_volume_group_with_bad_request
E0925 23:40:17.286035    3918 base.go:96] create volume group failed: db error
    --- PASS: TestCreateVolumeGroup/Should_return_400_if_create_volume_group_with_bad_request (0.00s)
=== RUN   TestListVolumeGroups
--- PASS: TestListVolumeGroups (0.00s)
=== RUN   TestListVolumeGroups/Should_return_200_if_everything_works_well
    --- PASS: TestListVolumeGroups/Should_return_200_if_everything_works_well (0.00s)
=== RUN   TestListVolumeGroups/Should_return_500_if_list_volume_groups_with_bad_request
E0925 23:40:17.289891    3918 base.go:96] list volume groups failed: db error
    --- PASS: TestListVolumeGroups/Should_return_500_if_list_volume_groups_with_bad_request (0.00s)
=== RUN   TestGetVolumeGroup
--- PASS: TestGetVolumeGroup (0.00s)
=== RUN   TestGetVolumeGroup/Should_return_200_if_everything_works_well
    --- PASS: TestGetVolumeGroup/Should_return_200_if_everything_works_well (0.00s)
=== RUN   TestGetVolumeGroup/Should_return_404_if_get_volume_group_resource_does_not_exist
E0925 23:40:17.293349    3918 base.go:96] volume group 3769855c-a102-11e7-b772-17b880d2f555 not found: db error
    --- PASS: TestGetVolumeGroup/Should_return_404_if_get_volume_group_resource_does_not_exist (0.00s)
=== RUN   TestUpdateVolumeGroup
--- PASS: TestUpdateVolumeGroup (0.00s)
=== RUN   TestUpdateVolumeGroup/Should_return_202_if_everything_works_well
    --- PASS: TestUpdateVolumeGroup/Should_return_202_if_everything_works_well (0.00s)
=== RUN   TestUpdateVolumeGroup/Should_return_400_if_update_volume_fails_with_bad_request
E0925 23:40:17.294524    3918 db.go:770] update group bd5b12a8-a101-11e7-941e-d77981b584d8 faild, because no valid name, description, addvolumes or removevolumes were provided
E0925 23:40:17.294619    3918 base.go:96] update volume group failed: update group bd5b12a8-a101-11e7-941e-d77981b584d8 faild, because no valid name, description, addvolumes or removevolumes were provided
    --- PASS: TestUpdateVolumeGroup/Should_return_400_if_update_volume_fails_with_bad_request (0.00s)
=== RUN   TestUpdateVolumeGroup/Should_return_400_if_update_volume_fails_with_bad_request_-_volume_group_not_found
E0925 23:40:17.294920    3918 base.go:96] update volume group failed: volume group bd5b12a8-a101-11e7-941e-d77981b584d8 not found:
    --- PASS: TestUpdateVolumeGroup/Should_return_400_if_update_volume_fails_with_bad_request_-_volume_group_not_found (0.00s)
=== RUN   TestDeleteVolumeGroup
--- PASS: TestDeleteVolumeGroup (0.00s)
=== RUN   TestDeleteVolumeGroup/Should_return_202_if_everything_works_well
    --- PASS: TestDeleteVolumeGroup/Should_return_202_if_everything_works_well (0.00s)
=== RUN   TestDeleteVolumeGroup/Should_return_404_-_specified_volume_group_id_can't_find_in_db
E0925 23:40:17.296166    3918 base.go:96] volume group 3769855c-a102-11e7-b772-17b880d2f555 not found: volume group 3769855c-a102-11e7-b772-17b880d2f555 not found: When get volume group in db
    --- PASS: TestDeleteVolumeGroup/Should_return_404_-_specified_volume_group_id_can't_find_in_db (0.00s)
PASS

Process finished with exit code 0

```
**Special notes for your reviewer**:
